### PR TITLE
remove types script

### DIFF
--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start",
-    "types": "tsc --noEmit"
+    "start": "next start"
   },
   "dependencies": {
     "@pathfinder/react": "workspace:*",


### PR DESCRIPTION
This PR removes the `tsc --noEmit` script from the nextjs example
