### PR TITLE
Refactor schema documentation component to accept schema as prop

### DIFF
--- a/.changeset/late-drinks-look.md
+++ b/.changeset/late-drinks-look.md
@@ -1,0 +1,5 @@
+---
+"@pathfinder-ide/react": patch
+---
+
+SchemaDocumentation and SchemaView components are now exported and can be used independently.

--- a/packages/react/src/ide/ide.tsx
+++ b/packages/react/src/ide/ide.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useThemeStore } from "@pathfinder-ide/stores";
+import { useSchemaStore, useThemeStore } from "@pathfinder-ide/stores";
 import { shared } from "@pathfinder-ide/style";
 
 import { Compass } from "../compass";
@@ -26,6 +26,8 @@ export const IDE = ({
   withSchemaProps?: boolean;
 }) => {
   const activeTheme = useThemeStore.use.activeTheme();
+
+  const schema = useSchemaStore.use.schema();
 
   const [visiblePane, setVisiblePane] = useState<string | null>("pathfinder");
 
@@ -97,7 +99,7 @@ export const IDE = ({
               isVisible: visiblePane === "schema_documentation",
             })}
           >
-            <SchemaDocumentation />
+            {schema ? <SchemaDocumentation schema={schema} /> : <></>}
           </div>
 
           <div
@@ -105,7 +107,7 @@ export const IDE = ({
               isVisible: visiblePane === "schema_view",
             })}
           >
-            <SchemaView />
+            {schema ? <SchemaView schema={schema} /> : <></>}
           </div>
         </div>
       </div>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,5 @@
-// component
 export { Pathfinder } from "./pathfinder";
+
+export { SchemaDocumentation } from "./schema-documentation";
+
+export { SchemaView } from "./schema-view";

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -1,5 +1,3 @@
-import { useSchemaStore } from "@pathfinder-ide/stores";
-
 import {
   SchemaDocumentationStoreProvider,
   useSchemaDocumentationStore,
@@ -23,18 +21,21 @@ import {
 } from "./schema-documentation.css";
 
 import { sharedPaneClass } from "../../shared.styles.css";
+import { GraphQLSchema } from "graphql";
 
-export const SchemaDocumentation = () => {
+type SchemaDocumentationProps = {
+  schema: GraphQLSchema;
+};
+
+export const SchemaDocumentation = ({ schema }: SchemaDocumentationProps) => {
   return (
     <SchemaDocumentationStoreProvider>
-      <SchemaDocumentationComponent />
+      <SchemaDocumentationComponent schema={schema} />
     </SchemaDocumentationStoreProvider>
   );
 };
 
-const SchemaDocumentationComponent = () => {
-  const schema = useSchemaStore.use.schema();
-
+const SchemaDocumentationComponent = ({ schema }: SchemaDocumentationProps) => {
   const { activePrimaryPane, activeTertiaryPane, tertiaryPaneStack } =
     useSchemaDocumentationStore();
 

--- a/packages/react/src/schema-documentation/schema-documentation.stories.tsx
+++ b/packages/react/src/schema-documentation/schema-documentation.stories.tsx
@@ -1,0 +1,6 @@
+import { SchemaDocumentation } from "./components/schema-documentation";
+import { testSchema } from "@pathfinder-ide/stores/src/schema-store/test-schema";
+
+export const WithSchema = () => {
+  return <SchemaDocumentation schema={testSchema} />;
+};

--- a/packages/react/src/schema-view/schema-view.stories.tsx
+++ b/packages/react/src/schema-view/schema-view.stories.tsx
@@ -1,0 +1,6 @@
+import { SchemaView } from "./schema-view";
+import { testSchema } from "@pathfinder-ide/stores/src/schema-store/test-schema";
+
+export const WithSchema = () => {
+  return <SchemaView schema={testSchema} />;
+};

--- a/packages/react/src/schema-view/schema-view.tsx
+++ b/packages/react/src/schema-view/schema-view.tsx
@@ -1,22 +1,22 @@
 import { useEffect } from "react";
-import { printSchema } from "graphql";
+import { GraphQLSchema, printSchema } from "graphql";
 
-import { getMonacoEditor, useSchemaStore } from "@pathfinder-ide/stores";
+import { getMonacoEditor } from "@pathfinder-ide/stores";
 
 import { Editor } from "../components";
 
 import { schemaViewInnerClass, schemaViewClass } from "./schema-view.css";
 
-export const SchemaView = () => {
-  const schema = useSchemaStore.use.schema();
+type SchemaViewProps = {
+  schema: GraphQLSchema;
+};
 
+export const SchemaView = ({ schema }: SchemaViewProps) => {
   useEffect(() => {
-    if (schema) {
-      const schemaViewEditor = getMonacoEditor({
-        editorId: "schema-view-editor",
-      });
-      schemaViewEditor?.setValue(printSchema(schema));
-    }
+    const schemaViewEditor = getMonacoEditor({
+      editorId: "schema-view-editor",
+    });
+    schemaViewEditor?.setValue(printSchema(schema));
   }, [schema]);
 
   if (!schema) {


### PR DESCRIPTION
This PR updates the SchemaDocumentation and SchemaView components to accept a schema as a prop and exports them from the react package.
