### PR TITLE
Export theme bits for use by integrators

### DIFF
--- a/.changeset/strong-cows-remain.md
+++ b/.changeset/strong-cows-remain.md
@@ -1,0 +1,5 @@
+---
+"@pathfinder-ide/react": patch
+---
+
+Export theme store functions to allow external control of theme. You can now import `setPathfinderTheme` and `usePathfinderThemeStore` if you need to set the theme (light/dark) from outside the Pathfinder UI.

--- a/examples/nextjs-example/src/app/page.tsx
+++ b/examples/nextjs-example/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 
+// dynamically import our React component
 const Pathfinder = dynamic(
   () => import('@pathfinder-ide/react').then(mod => mod.Pathfinder),
   {
@@ -13,8 +14,25 @@ import "@pathfinder-ide/react/dist/style.css";
 
 export default function Home() {
   return (
-    <main className="flex h-full flex-col items-center text-blue-700">
-      My cool Next.js app
+    <main className="flex h-full flex-col items-center">
+      <div className="flex items-center gap-4 text-blue-700">
+        <h1>My cool Next.js app</h1>
+        <button 
+        className="text-pink-700"
+        onClick={async () => {
+          // these imports include calls to navigator (via monaco editor), so we dynamically import the data and function that we need to adjust the theme
+          const activeTheme = (await import('@pathfinder-ide/react')).usePathfinderThemeStore.getState().activeTheme
+          const setPathfinderTheme = (await import('@pathfinder-ide/react')).setPathfinderTheme
+          
+          if (activeTheme === "dark") {
+            setPathfinderTheme({theme: "light"})
+          }
+          if (activeTheme === "light") {
+            setPathfinderTheme({theme: "dark"})
+          }          
+        }}>Toggle theme</button>
+      </div>
+    
       <Pathfinder 
         schemaProps={{
           fetcherOptions: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pathfinde-ide",
+  "name": "pathfinder-ide",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.17",
+    "@pathfinder-ide/stores": "workspace:*",
     "graphql": "16.8.1",
     "idb-keyval": "6.2.1",
     "monaco-editor": "0.40.0",
@@ -41,7 +42,6 @@
   "devDependencies": {
     "@pathfinder-ide/eslint-config": "workspace:*",
     "@pathfinder-ide/shared": "workspace:*",
-    "@pathfinder-ide/stores": "workspace:*",
     "@pathfinder-ide/style": "workspace:*",
     "@pathfinder-ide/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "6.1.3",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,10 @@
+// store functions
+export {
+  setTheme as setPathfinderTheme,
+  useThemeStore as usePathfinderThemeStore,
+} from "@pathfinder-ide/stores";
+
+// components
 export { Pathfinder } from "./pathfinder";
 
 export { SchemaDocumentation } from "./schema-documentation";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       '@headlessui/react':
         specifier: 1.7.17
         version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
+      '@pathfinder-ide/stores':
+        specifier: workspace:*
+        version: link:../stores
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -267,9 +270,6 @@ importers:
       '@pathfinder-ide/shared':
         specifier: workspace:*
         version: link:../shared
-      '@pathfinder-ide/stores':
-        specifier: workspace:*
-        version: link:../stores
       '@pathfinder-ide/style':
         specifier: workspace:*
         version: link:../style
@@ -11324,6 +11324,7 @@ packages:
       react-dom: ^18.2.0
     dependencies:
       '@headlessui/react': 1.7.17(react-dom@18.2.0)(react@18.2.0)
+      '@pathfinder-ide/stores': link:packages/stores
       graphql: 16.8.1
       idb-keyval: 6.2.1
       monaco-editor: 0.40.0


### PR DESCRIPTION
This PR re-exports `setPathfinderTheme` and `usePathfinderThemeStore` from our published package to allow implementors to set the Pathfinder theme from outside the Pathfinder UI.
