### PR TITLE
run react:build before types check to prevent nextjs-example from err…

### DIFF
--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "types:check": "tsc --noEmit"
+    "types": "tsc --noEmit"
   },
   "dependencies": {
     "@pathfinder-ide/react": "file:../../packages/react",    

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ladle:preview": "pnpm --filter ladle preview",
     "ladle:serve": "pnpm --filter ladle serve",
     "version-packages": "changeset version",
-    "release": "pnpm run types && pnpm run react:build && changeset publish"
+    "release": "pnpm run react:build && pnpm run types && changeset publish"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
This simple PR ensures that the `react` package is built before running the `types` check, which was failing in the nextjs-example.
