### PR TITLE
back to types:check to avoid nextjs-example types running in ci

### DIFF
--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
-    "types": "tsc --noEmit"
+    "types:check": "tsc --noEmit"
   },
   "dependencies": {
     "@pathfinder-ide/react": "file:../../packages/react",    


### PR DESCRIPTION
Running `tsc --noEmit` in the `nextjs-example` app via ci is breaking because the example depends on `react` being built and installed in order to pass the types check. This PR, once again, renames the type check script to `types:check` so that it doesn't run as part of the turbo command.
