### PR TITLE
Fix /stores for release

### DIFF
--- a/.changeset/happy-pens-try.md
+++ b/.changeset/happy-pens-try.md
@@ -1,0 +1,5 @@
+---
+"@pathfinder-ide/react": patch
+---
+
+Test release: Moves `stores` back to devDependencies.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.17",
-    "@pathfinder-ide/stores": "workspace:*",
     "graphql": "16.8.1",
     "idb-keyval": "6.2.1",
     "monaco-editor": "0.40.0",
@@ -42,6 +41,7 @@
   "devDependencies": {
     "@pathfinder-ide/eslint-config": "workspace:*",
     "@pathfinder-ide/shared": "workspace:*",
+    "@pathfinder-ide/stores": "workspace:*",
     "@pathfinder-ide/style": "workspace:*",
     "@pathfinder-ide/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,9 +239,6 @@ importers:
       '@headlessui/react':
         specifier: 1.7.17
         version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
-      '@pathfinder-ide/stores':
-        specifier: workspace:*
-        version: link:../stores
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -273,6 +270,9 @@ importers:
       '@pathfinder-ide/shared':
         specifier: workspace:*
         version: link:../shared
+      '@pathfinder-ide/stores':
+        specifier: workspace:*
+        version: link:../stores
       '@pathfinder-ide/style':
         specifier: workspace:*
         version: link:../style
@@ -11326,6 +11326,7 @@ packages:
     resolution: {directory: packages/react, type: directory}
     id: file:packages/react
     name: '@pathfinder-ide/react'
+    version: 0.2.0
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0


### PR DESCRIPTION
This PR moves the dependency on the `stores` package back to `devDependencies`. A changeset is attached to this PR, so this should kick off a patch release that can be tested.