### PR TITLE
Gb 5122 increase monaco editor default font size

### DIFF
--- a/.changeset/tender-mayflies-agree.md
+++ b/.changeset/tender-mayflies-agree.md
@@ -1,0 +1,5 @@
+---
+"@pathfinder-ide/react": patch
+---
+
+Increases default font size for monaco editors

--- a/packages/react/src/components/button/button.css.ts
+++ b/packages/react/src/components/button/button.css.ts
@@ -9,7 +9,7 @@ export const buttonClass = recipe({
       alignItems: "center",
       gap: contract.space[2],
       borderRadius: contract.space[2],
-      fontSize: 12,
+      fontSize: 13,
       fontWeight: 400,
       transition: `all .075s ${shared.transitions.authenticMotion}`,
       color: contract.color.neutral[11],

--- a/packages/stores/src/monaco-editor-store/helpers/editor-options.ts
+++ b/packages/stores/src/monaco-editor-store/helpers/editor-options.ts
@@ -8,7 +8,7 @@ export const editorOptions: MonacoEditorStandaloneEditorConstructionOptions = {
   fixedOverflowWidgets: true,
   fontFamily:
     "'Hack', 'Fira Code', Consolas, 'Andale Mono WT', 'Andale Mono', 'Lucida Console', 'Lucida Sans Typewriter', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Liberation Mono', 'Nimbus Mono L', Monaco, 'Courier New', Courier, monospace",
-  fontSize: 12, // default is 12
+  fontSize: 14, // default is 12
   lineNumbersMinChars: 2,
   minimap: {
     enabled: false, // disable the minimap


### PR DESCRIPTION
This PR increases the default `monaco-editor` font size.
