### PR TITLE
add Types Check workflow on PR open/sync

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,28 @@
+name: Types Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  types_check:
+    name: Types Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install  
+
+      - name: Do types check
+        run: pnpm types
+

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   types_check:
-    name: Types Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,4 +1,4 @@
-name: Types Check
+name: lint/types
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   types_check:
+    name: check types
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds a simple `tsc --noEmit` check across the repo on PR open/sync.
