### PR TITLE
Gb 5169 pathfinder should accept a default theme name as a prop

### DIFF
--- a/.changeset/big-maps-know.md
+++ b/.changeset/big-maps-know.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': minor
+---
+
+Updates the `themeOptions` prop to include a `defaultTheme` ("light" | "dark" | "system"). If the `defaultTheme` is either "light" or "dark", Pathfinder will respect the choice. If the prop is not passed, or passed as "system", Pathfinder will listen for changes to `prefers-color-scheme` and respond accordingly.

--- a/packages/react/src/pathfinder/pathfinder.stories.tsx
+++ b/packages/react/src/pathfinder/pathfinder.stories.tsx
@@ -43,6 +43,39 @@ export const FullModeWithoutSchemaProps = () => {
   return <Pathfinder />;
 };
 
+export const FullModeWithDefaultThemeDark = () => {
+  return (
+    <Pathfinder
+      fetcherOptions={fetcherOptions}
+      themeOptions={{
+        defaultTheme: 'dark',
+      }}
+    />
+  );
+};
+
+export const FullModeWithDefaultThemeLight = () => {
+  return (
+    <Pathfinder
+      fetcherOptions={fetcherOptions}
+      themeOptions={{
+        defaultTheme: 'light',
+      }}
+    />
+  );
+};
+
+export const FullModeWithDefaultThemeSystem = () => {
+  return (
+    <Pathfinder
+      fetcherOptions={fetcherOptions}
+      themeOptions={{
+        defaultTheme: 'system',
+      }}
+    />
+  );
+};
+
 export const FullModeWithThemeOverrides = () => {
   return (
     <Pathfinder
@@ -51,7 +84,7 @@ export const FullModeWithThemeOverrides = () => {
         enabled: true,
       }}
       themeOptions={{
-        theme: { overrides },
+        overrides,
       }}
     />
   );

--- a/packages/react/src/pathfinder/pathfinder.test.tsx
+++ b/packages/react/src/pathfinder/pathfinder.test.tsx
@@ -42,7 +42,7 @@ describe('Pathfinder props', () => {
       <Pathfinder
         fetcherOptions={{ endpoint: 'ENDPOINT' }}
         themeOptions={{
-          theme: { overrides },
+          overrides,
         }}
       />,
     );

--- a/packages/react/src/pathfinder/pathfinder.tsx
+++ b/packages/react/src/pathfinder/pathfinder.tsx
@@ -32,7 +32,7 @@ export const Pathfinder = ({
 
   useEffect(() => {
     // set the theme and handle overrides if provided
-    initializeTheme({ overrides: themeOptions?.theme?.overrides });
+    initializeTheme({ options: themeOptions });
 
     //set our schema polling options if provided
     if (schemaPollingOptions) {

--- a/packages/react/src/pathfinder/pathfinder.types.ts
+++ b/packages/react/src/pathfinder/pathfinder.types.ts
@@ -1,6 +1,8 @@
-import type { ThemeContractOverrides } from '@pathfinder-ide/style';
-
-import { HTTPHeaderValue, SchemaStoreState } from '@pathfinder-ide/stores';
+import type {
+  HTTPHeaderValue,
+  SchemaStoreState,
+  ThemeOptions,
+} from '@pathfinder-ide/stores';
 
 export type PathfinderProps = {
   mode?: 'FULL' | 'MINI';
@@ -11,9 +13,5 @@ export type PathfinderProps = {
   schemaPollingOptions?: Partial<
     Pick<SchemaStoreState['polling'], 'enabled' | 'interval'>
   >;
-  themeOptions?: {
-    theme?: {
-      overrides?: ThemeContractOverrides;
-    };
-  };
+  themeOptions?: Partial<ThemeOptions>;
 };

--- a/packages/stores/src/monaco-editor-store/helpers/editor-theme.ts
+++ b/packages/stores/src/monaco-editor-store/helpers/editor-theme.ts
@@ -1,5 +1,3 @@
-import type { AvailableThemes } from '@pathfinder-ide/shared';
-
 import type monaco from 'monaco-graphql/esm/monaco-editor';
 
 type MonacoEditorStandaloneThemeData = monaco.editor.IStandaloneThemeData;
@@ -48,7 +46,7 @@ export const colorsForEditor = {
 export const editorTheme = ({
   variant,
 }: {
-  variant: AvailableThemes;
+  variant: 'dark' | 'light';
 }): MonacoEditorStandaloneThemeData => ({
   base: variant === 'light' ? 'vs' : 'vs-dark',
   inherit: true,

--- a/packages/stores/src/theme-store/actions/initialize-theme.ts
+++ b/packages/stores/src/theme-store/actions/initialize-theme.ts
@@ -1,21 +1,21 @@
-import { ThemeContractOverrides, getPrefersColorScheme } from '@pathfinder-ide/style';
 import { setTheme } from './set-theme';
 import { setThemeOverrides } from './set-theme-overrides';
-import { AvailableThemes } from '@pathfinder-ide/shared';
+import { ThemeOptions } from '../theme-store.types';
+import { listenForPrefersColorSchemeChange } from './listen-for-prefers-color-scheme-change';
 
 export const initializeTheme = ({
-  overrides,
+  options = { defaultTheme: 'system' },
 }: {
-  overrides?: ThemeContractOverrides;
+  options?: ThemeOptions;
 }) => {
   // if we receive theme overrides, set them to state here
-  if (overrides) {
-    setThemeOverrides({ overrides });
+  if (options.overrides) {
+    setThemeOverrides({ overrides: options.overrides });
   }
 
-  let preference: AvailableThemes = 'light';
-
-  preference = getPrefersColorScheme();
-
-  return setTheme({ theme: preference });
+  if (options.defaultTheme === 'dark' || options.defaultTheme === 'light') {
+    return setTheme({ theme: options.defaultTheme });
+  } else {
+    return listenForPrefersColorSchemeChange();
+  }
 };

--- a/packages/stores/src/theme-store/actions/listen-for-prefers-color-scheme-change.ts
+++ b/packages/stores/src/theme-store/actions/listen-for-prefers-color-scheme-change.ts
@@ -1,0 +1,22 @@
+import { setTheme } from './set-theme';
+
+let remove: (() => void) | null = null;
+
+export const listenForPrefersColorSchemeChange = () => {
+  if (remove != null) {
+    remove();
+  }
+  const media = matchMedia('(prefers-color-scheme:dark)');
+
+  if (media.matches) {
+    setTheme({ theme: 'dark' });
+  } else {
+    setTheme({ theme: 'light' });
+  }
+
+  media.addEventListener('change', listenForPrefersColorSchemeChange);
+
+  remove = () => {
+    media.removeEventListener('change', listenForPrefersColorSchemeChange);
+  };
+};

--- a/packages/stores/src/theme-store/index.ts
+++ b/packages/stores/src/theme-store/index.ts
@@ -1,5 +1,7 @@
 export { initializeTheme, setTheme } from './actions';
 
+export type { ThemeOptions } from './theme-store.types';
+
 export { themeStore } from './theme-store';
 
 export { useThemeStore } from './use-theme-store';

--- a/packages/stores/src/theme-store/theme-store.types.ts
+++ b/packages/stores/src/theme-store/theme-store.types.ts
@@ -1,5 +1,10 @@
 import type { AvailableThemes } from '@pathfinder-ide/shared';
-import { ThemeContractOverrides } from '@pathfinder-ide/style';
+import type { ThemeContractOverrides } from '@pathfinder-ide/style';
+
+export type ThemeOptions = {
+  defaultTheme?: AvailableThemes | 'system';
+  overrides?: ThemeContractOverrides;
+};
 
 type ThemeStoreState = {
   activeTheme: AvailableThemes | null;

--- a/packages/style/src/index.ts
+++ b/packages/style/src/index.ts
@@ -20,4 +20,4 @@ export { contract } from './theme';
 
 export type { ThemeContractOverrides } from './types';
 
-export { getPrefersColorScheme, toTitleCase } from './utils';
+export { toTitleCase } from './utils';

--- a/packages/style/src/utils/get-prefers-color-scheme.ts
+++ b/packages/style/src/utils/get-prefers-color-scheme.ts
@@ -1,9 +1,0 @@
-import type { AvailableThemes } from '@pathfinder-ide/shared';
-
-export const getPrefersColorScheme = (): AvailableThemes => {
-  if (window.matchMedia('(prefers-color-scheme:dark)').matches) {
-    return 'dark';
-  } else {
-    return 'light';
-  }
-};

--- a/packages/style/src/utils/index.ts
+++ b/packages/style/src/utils/index.ts
@@ -1,3 +1,1 @@
-export { getPrefersColorScheme } from './get-prefers-color-scheme';
-
 export { toTitleCase } from './to-title-case';


### PR DESCRIPTION
This PR updates the `themeOptions` prop to include a `defaultTheme` ("light" | "dark" | "system"). If the `defaultTheme` is either "light" or "dark", Pathfinder will respect the choice. If the prop is not passed, or passed as "system", Pathfinder will listen for changes to `prefers-color-scheme` and respond accordingly.