### PR TITLE
lock node to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "5.2.2"
   },
   "engines": {
-    "node": "^18",
+    "node": "18.x",
     "pnpm": "^8"
   }
 }


### PR DESCRIPTION
Let's prevent renovate from trying to update node by locking node to 18.x in engines.
