### PR TITLE
Reset stores when pathfinder components unmounts

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,11 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@pathfinder-ide/website", "nextjs-example", "desktop", "ladle"]
+  "ignore": [
+    "@pathfinder-ide/website",
+    "nextjs-example",
+    "vite-example",
+    "desktop",
+    "ladle"
+  ]
 }

--- a/.changeset/fifty-games-grow.md
+++ b/.changeset/fifty-games-grow.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Reset state when Pathfinder unmounts.

--- a/packages/react/src/compass/compass.css.ts
+++ b/packages/react/src/compass/compass.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@pathfinder-ide/style';
+import { contract, style } from '@pathfinder-ide/style';
 
 export const compassClass = style({
   position: 'relative',
@@ -6,4 +6,17 @@ export const compassClass = style({
   width: '100%',
   boxSizing: 'border-box',
   overflow: 'hidden',
+});
+
+export const compassSkeletonClass = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 12,
+  position: 'relative',
+  height: '100%',
+  width: '100%',
+  color: contract.color.neutral[11],
+  fontFamily: contract.fonts.mono,
+  fontSize: 12,
 });

--- a/packages/react/src/compass/compass.tsx
+++ b/packages/react/src/compass/compass.tsx
@@ -5,8 +5,8 @@ import { Kind, OperationTypeNode } from 'graphql';
 import { useGraphQLDocumentStore, useSchemaStore } from '@pathfinder-ide/stores';
 
 import { QuickDocs, RootOperation } from './components';
-import { compassClass } from './compass.css';
-import { Tabs } from '../components';
+import { compassClass, compassSkeletonClass } from './compass.css';
+import { CompassAnimated, Tabs } from '../components';
 import { TabsProps } from '../components/tabs/tabs.types';
 
 import {
@@ -54,7 +54,12 @@ const CompassComponent = () => {
   }, [operationDefinition, schema]);
 
   if (!schema) {
-    return null;
+    return (
+      <div className={compassSkeletonClass}>
+        <span>Loading schema...</span>
+        <CompassAnimated size="small" speed="standard" />
+      </div>
+    );
   }
 
   const buildTabData = () => {

--- a/packages/react/src/components/compass-animated/compass-animated.css.ts
+++ b/packages/react/src/components/compass-animated/compass-animated.css.ts
@@ -1,8 +1,6 @@
 import { contract, keyframes, recipe, shared, style } from '@pathfinder-ide/style';
 
 export const compassAnimatedWrapClass = style({
-  width: '100%',
-  height: '100%',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/packages/react/src/components/editor/editor.css.ts
+++ b/packages/react/src/components/editor/editor.css.ts
@@ -11,7 +11,7 @@ export const editorClass = recipe({
     minWidth: 0,
 
     // a little hack to prevent the potential flash of alternate editor theme colors on initialization
-    transition: 'opacity .15s ease',
+    transition: 'opacity 0.35s ease',
   },
 
   variants: {

--- a/packages/react/src/pathfinder/pathfinder.stories.tsx
+++ b/packages/react/src/pathfinder/pathfinder.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Pathfinder } from './pathfinder';
 import { PathfinderProps } from './pathfinder.types';
 
@@ -28,10 +29,73 @@ const fetcherOptions: PathfinderProps['fetcherOptions'] = {
   ],
 };
 
-export const ReferenceMode = () => {
+export const ToggleReference = () => {
+  const [visibleP, setVisibleP] = useState<'X' | 'N'>('X');
+  return (
+    <>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <button
+          style={{
+            all: 'unset',
+            padding: 12,
+            backgroundColor: visibleP === 'X' ? 'green' : 'red',
+            cursor: 'pointer',
+          }}
+          onClick={() => setVisibleP('X')}
+        >
+          ENV API
+        </button>
+        <button
+          style={{
+            all: 'unset',
+            padding: 12,
+            backgroundColor: visibleP === 'N' ? 'green' : 'red',
+            cursor: 'pointer',
+          }}
+          onClick={() => setVisibleP('N')}
+        >
+          NASA API
+        </button>
+      </div>
+      {visibleP === 'X' && (
+        <Pathfinder
+          fetcherOptions={fetcherOptions}
+          schemaPollingOptions={{
+            enabled: true,
+          }}
+        />
+      )}
+      {visibleP === 'N' && (
+        <Pathfinder
+          fetcherOptions={{
+            endpoint: 'https://graphql.earthdata.nasa.gov/api',
+          }}
+          schemaPollingOptions={{
+            enabled: true,
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export const ReferenceModeENVAPI = () => {
   return (
     <Pathfinder
       fetcherOptions={fetcherOptions}
+      schemaPollingOptions={{
+        enabled: true,
+      }}
+    />
+  );
+};
+
+export const ReferenceModeNASA = () => {
+  return (
+    <Pathfinder
+      fetcherOptions={{
+        endpoint: 'https://graphql.earthdata.nasa.gov/api',
+      }}
       schemaPollingOptions={{
         enabled: true,
       }}

--- a/packages/stores/src/cleanup-stores.ts
+++ b/packages/stores/src/cleanup-stores.ts
@@ -1,0 +1,33 @@
+import { graphQLDocumentStore } from './graphql-document-store';
+import { INITIAL_GRAPHQL_DOCUMENT_STATE } from './graphql-document-store/state';
+import {
+  monacoEditorStore,
+  INITIAL_MONACO_EDITOR_STORE_STATE,
+} from './monaco-editor-store';
+import { monacoGraphQLStore } from './monaco-graphql-store';
+import { INITIAL_MONACO_GRAPHQL_STORE_STATE } from './monaco-graphql-store/monaco-graphql-store';
+import {
+  resetSchemaPolling,
+  schemaStore,
+  INITIAL_SCHEMA_STORE_STATE,
+} from './schema-store';
+
+export const cleanupStores = () => {
+  const managedEditors = monacoEditorStore.getState().managedEditors;
+
+  // manually dispose of editors and models _before_ resetting the store state below
+  Object.values(managedEditors).forEach((editor) => {
+    editor?.getModel()?.dispose();
+    editor?.dispose();
+  });
+
+  resetSchemaPolling();
+
+  graphQLDocumentStore.setState({ ...INITIAL_GRAPHQL_DOCUMENT_STATE });
+
+  monacoEditorStore.setState({ ...INITIAL_MONACO_EDITOR_STORE_STATE });
+
+  monacoGraphQLStore.setState({ ...INITIAL_MONACO_GRAPHQL_STORE_STATE });
+
+  schemaStore.setState({ ...INITIAL_SCHEMA_STORE_STATE });
+};

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -37,6 +37,10 @@ export type { ExecutionResponse, SchemaStoreState } from './schema-store';
 
 export { getNamespacedStorageName } from './storage';
 
+export * from './session-store';
+
 export * from './theme-store';
 
-export * from './session-store';
+export * from './ui-store';
+
+export { cleanupStores } from './cleanup-stores';

--- a/packages/stores/src/monaco-editor-store/actions/dispose-monaco-editor.ts
+++ b/packages/stores/src/monaco-editor-store/actions/dispose-monaco-editor.ts
@@ -18,6 +18,7 @@ export const disposeMonacoEditor: MonacoEditorStoreActions['disposeMonacoEditor'
 
   // if so, we call dispose() to remove it from monaco's global instance
   if (editorToDispose) {
+    editorToDispose.getModel()?.dispose();
     editorToDispose.dispose();
 
     if (

--- a/packages/stores/src/monaco-editor-store/index.ts
+++ b/packages/stores/src/monaco-editor-store/index.ts
@@ -19,3 +19,5 @@ export type {
   MonacoEditorITextModel,
   MonacoEditorIActionDescriptor,
 } from './monaco-editor-store.types';
+
+export { INITIAL_MONACO_EDITOR_STORE_STATE } from './state';

--- a/packages/stores/src/monaco-editor-store/state.ts
+++ b/packages/stores/src/monaco-editor-store/state.ts
@@ -6,7 +6,7 @@ import {
 
 import type { MonacoEditorStoreState } from './monaco-editor-store.types';
 
-const INITIAL_MONACO_EDITOR_STORE_STATE: MonacoEditorStoreState = {
+export const INITIAL_MONACO_EDITOR_STORE_STATE: MonacoEditorStoreState = {
   managedEditors: {
     [DOCUMENT_EDITOR_ID]: null,
     [RESPONSE_EDITOR_ID]: null,

--- a/packages/stores/src/monaco-graphql-store/monaco-graphql-store.ts
+++ b/packages/stores/src/monaco-graphql-store/monaco-graphql-store.ts
@@ -2,6 +2,10 @@ import { create } from 'zustand';
 
 import { MonacoGraphQLStoreState } from './monaco-graphql-store.types';
 
-export const monacoGraphQLStore = create<MonacoGraphQLStoreState>()(() => ({
+export const INITIAL_MONACO_GRAPHQL_STORE_STATE = {
   monacoGraphQLAPI: null,
+};
+
+export const monacoGraphQLStore = create<MonacoGraphQLStoreState>()(() => ({
+  ...INITIAL_MONACO_GRAPHQL_STORE_STATE,
 }));

--- a/packages/stores/src/schema-store/index.ts
+++ b/packages/stores/src/schema-store/index.ts
@@ -16,3 +16,5 @@ export type {
 export { schemaStore } from './schema-store';
 
 export { useSchemaStore } from './use-schema-store';
+
+export { INITIAL_SCHEMA_STORE_STATE } from './state';

--- a/packages/stores/src/session-store/actions/init-session.ts
+++ b/packages/stores/src/session-store/actions/init-session.ts
@@ -11,6 +11,7 @@ import { useSessionStore } from '../use-session-store';
 import { INITIAL_EDITOR_TAB } from '../slices/editor-tabs/editor-tabs-state';
 import { setEditorValues } from '../slices/editor-tabs/actions/set-editor-values';
 import { INITIAL_HTTP_HEADERS_STATE } from '../slices/http-headers/http-headers-state';
+import { uiStore } from '../../ui-store';
 
 export const initSession = async ({
   fetchOptions,
@@ -38,6 +39,10 @@ export const initSession = async ({
     activeTab: INITIAL_EDITOR_TAB,
     tabs: [INITIAL_EDITOR_TAB],
     variablesString: VARIABLES_EDITOR_DEFAULT_VALUE,
+  });
+
+  uiStore.setState({
+    isHydrated: true,
   });
 
   loadSchema({

--- a/packages/stores/src/session-store/actions/load-session.ts
+++ b/packages/stores/src/session-store/actions/load-session.ts
@@ -3,14 +3,14 @@ import { loadSchema } from '../../schema-store';
 import { setEditorValues } from '../slices/editor-tabs/actions/set-editor-values';
 import { useSessionStore } from '../use-session-store';
 
-export const loadSession = ({ sessionName }: { sessionName: string }) => {
+export const loadSession = async ({ sessionName }: { sessionName: string }) => {
   // if we have an existing session is storage, we set the name/rehydrate/load the schema
   useSessionStore.persist.setOptions({
     name: sessionName,
   });
 
   // manually rehydrate
-  useSessionStore.persist.rehydrate();
+  await useSessionStore.persist.rehydrate();
 
   // wait a short amount of time to allow for rehydration
   setTimeout(() => {

--- a/packages/stores/src/session-store/session-store-state.ts
+++ b/packages/stores/src/session-store/session-store-state.ts
@@ -1,7 +1,6 @@
 import type { SessionStoreBaseState } from './session-store.types';
 
 export const sessionStoreState: SessionStoreBaseState = {
-  _hasHydrated: false,
   endpoint: null,
   connectionDialogOpen: false,
 };

--- a/packages/stores/src/session-store/session-store.ts
+++ b/packages/stores/src/session-store/session-store.ts
@@ -13,6 +13,7 @@ import { variablesState } from './slices/variables';
 import { sessionStoreState } from './session-store-state';
 
 import { SessionStoreState } from './session-store.types';
+import { uiStore } from '../ui-store';
 
 type StateToPersist = Omit<SessionStoreState, '_hasHydrated' | 'connectionDialogOpen'>;
 
@@ -33,8 +34,11 @@ export const sessionStore = createStore<SessionStoreState>()(
       onRehydrateStorage: () => {
         return (_state, error) => {
           if (error) {
-            console.warn('an error occurred during sessionStore hydration', error);
+            return console.warn('an error occurred during sessionStore hydration', error);
           }
+          uiStore.setState({
+            isHydrated: true,
+          });
         };
       },
       partialize: (state) => ({

--- a/packages/stores/src/session-store/session-store.types.ts
+++ b/packages/stores/src/session-store/session-store.types.ts
@@ -5,10 +5,6 @@ import type { VariablesState } from './slices/variables';
 
 export type SessionStoreBaseState = {
   /**
-   * A boolean indicating whether Zustand's persist middleware has rehydrated our state
-   */
-  _hasHydrated: boolean;
-  /**
    * The current target GraphQL endpoint
    */
   endpoint?: string | null;

--- a/packages/stores/src/ui-store/index.ts
+++ b/packages/stores/src/ui-store/index.ts
@@ -1,0 +1,1 @@
+export { uiStore } from './ui-store';

--- a/packages/stores/src/ui-store/ui-store.ts
+++ b/packages/stores/src/ui-store/ui-store.ts
@@ -1,0 +1,7 @@
+import { createStore } from 'zustand/vanilla';
+
+import { UIStore } from './ui-store.types';
+
+export const uiStore = createStore<UIStore>()(() => ({
+  isHydrated: false,
+}));

--- a/packages/stores/src/ui-store/ui-store.types.ts
+++ b/packages/stores/src/ui-store/ui-store.types.ts
@@ -1,0 +1,5 @@
+type UIStoreState = {
+  isHydrated: boolean;
+};
+
+export type UIStore = UIStoreState;


### PR DESCRIPTION
This PR introduces a fix for a state issue we see at Grafbase. When users navigate between projects and their Pathfinder pages, previous Pathfinder data is briefly displayed before the proper session is hydrated and the new schema is introspected.

- Move the `isHydrated` boolean flag outside of the session store so that we can call it without affecting persistence
- Implement a `cleanupStores` function to run when the Pathfinder component unmounts. This function sets critical stores back to their initial state.