### PR TITLE
Fix issue with monaco editors not initializing on load

### DIFF
--- a/.changeset/new-walls-accept.md
+++ b/.changeset/new-walls-accept.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Fixes an issue with Monaco editors disposing prematurely when PathfinderProps change.

--- a/packages/react/src/pathfinder/pathfinder.stories.tsx
+++ b/packages/react/src/pathfinder/pathfinder.stories.tsx
@@ -19,70 +19,124 @@ const overrides = {
   },
 };
 
-const fetcherOptions: PathfinderProps['fetcherOptions'] = {
-  endpoint: import.meta.env.VITE_GRAPHQL_ENDPOINT,
-  headers: [
-    {
-      key: import.meta.env.VITE_GRAPHQL_AUTHHEADER_KEY,
-      value: import.meta.env.VITE_GRAPHQL_AUTHHEADER_VALUE,
-    },
-  ],
+type ToggleReferenceProps = {
+  fetcherOptions: PathfinderProps['fetcherOptions'];
+  name: 'NASA_API' | 'ENV_API';
+};
+
+const ENV_API: ToggleReferenceProps = {
+  name: 'ENV_API',
+  fetcherOptions: {
+    endpoint: import.meta.env.VITE_GRAPHQL_ENDPOINT,
+    headers: [
+      {
+        key: import.meta.env.VITE_GRAPHQL_AUTHHEADER_KEY,
+        value: import.meta.env.VITE_GRAPHQL_AUTHHEADER_VALUE,
+      },
+    ],
+  },
+};
+
+const NASA_API: ToggleReferenceProps = {
+  name: 'NASA_API',
+  fetcherOptions: {
+    endpoint: 'https://graphql.earthdata.nasa.gov/api',
+  },
 };
 
 export const ToggleReference = () => {
-  const [visibleP, setVisibleP] = useState<'X' | 'N'>('X');
+  const [endpoint, setEndpoint] = useState<ToggleReferenceProps>(NASA_API);
+  const [visibleTogglePane, setVisibleTogglePane] = useState<
+    null | 'NASA_API' | 'ENV_API'
+  >(null);
+  console.log('ToggleReference', { endpoint });
   return (
-    <>
-      <div style={{ display: 'flex', gap: 12 }}>
-        <button
-          style={{
-            all: 'unset',
-            padding: 12,
-            backgroundColor: visibleP === 'X' ? 'green' : 'red',
-            cursor: 'pointer',
-          }}
-          onClick={() => setVisibleP('X')}
-        >
-          ENV API
-        </button>
-        <button
-          style={{
-            all: 'unset',
-            padding: 12,
-            backgroundColor: visibleP === 'N' ? 'green' : 'red',
-            cursor: 'pointer',
-          }}
-          onClick={() => setVisibleP('N')}
-        >
-          NASA API
-        </button>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateRows: '60px 1fr',
+        height: '100%',
+        width: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{ display: 'flex', gap: 12, height: 60, justifyContent: 'space-between' }}
+      >
+        <div>
+          <button
+            style={{
+              padding: 12,
+              backgroundColor: 'white',
+              color: 'black',
+              opacity: endpoint.name === 'ENV_API' ? 1 : 0.35,
+
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              setEndpoint(ENV_API);
+              setVisibleTogglePane(null);
+            }}
+          >
+            ENV API
+          </button>
+          <button
+            style={{
+              padding: 12,
+              backgroundColor: 'white',
+              color: 'black',
+              opacity: endpoint.name === 'NASA_API' ? 1 : 0.35,
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              setEndpoint(NASA_API);
+              setVisibleTogglePane(null);
+            }}
+          >
+            NASA API
+          </button>
+        </div>
+        <div>
+          <button
+            style={{
+              padding: 12,
+              backgroundColor: visibleTogglePane === 'ENV_API' ? 'green' : 'red',
+              color: 'black',
+              cursor: 'pointer',
+            }}
+            onClick={() => setVisibleTogglePane('ENV_API')}
+          >
+            ENV API
+          </button>
+          <button
+            style={{
+              padding: 12,
+              backgroundColor: visibleTogglePane === 'NASA_API' ? 'green' : 'red',
+              cursor: 'pointer',
+            }}
+            onClick={() => setVisibleTogglePane('NASA_API')}
+          >
+            NASA API
+          </button>
+        </div>
       </div>
-      {visibleP === 'X' && (
-        <Pathfinder
-          fetcherOptions={fetcherOptions}
-          schemaPollingOptions={{
-            enabled: true,
-          }}
-        />
+      {visibleTogglePane === null && (
+        <Pathfinder fetcherOptions={endpoint.fetcherOptions} />
       )}
-      {visibleP === 'N' && (
-        <Pathfinder
-          fetcherOptions={{
-            endpoint: 'https://graphql.earthdata.nasa.gov/api',
-          }}
-          schemaPollingOptions={{
-            enabled: true,
-          }}
-        />
+      {visibleTogglePane === 'ENV_API' && (
+        <Pathfinder fetcherOptions={ENV_API.fetcherOptions} />
       )}
-    </>
+      {visibleTogglePane === 'NASA_API' && (
+        <Pathfinder fetcherOptions={NASA_API.fetcherOptions} />
+      )}
+    </div>
   );
 };
 
 export const ReferenceModeENVAPI = () => {
   return (
     <Pathfinder
-      fetcherOptions={fetcherOptions}
+      fetcherOptions={ENV_API.fetcherOptions}
       schemaPollingOptions={{
         enabled: true,
       }}
@@ -110,7 +164,7 @@ export const ReferenceModeWithoutSchemaProps = () => {
 export const ReferenceModeWithDefaultThemeDark = () => {
   return (
     <Pathfinder
-      fetcherOptions={fetcherOptions}
+      fetcherOptions={ENV_API.fetcherOptions}
       themeOptions={{
         defaultTheme: 'dark',
       }}
@@ -121,7 +175,7 @@ export const ReferenceModeWithDefaultThemeDark = () => {
 export const ReferenceModeWithDefaultThemeLight = () => {
   return (
     <Pathfinder
-      fetcherOptions={fetcherOptions}
+      fetcherOptions={ENV_API.fetcherOptions}
       themeOptions={{
         defaultTheme: 'light',
       }}
@@ -132,7 +186,7 @@ export const ReferenceModeWithDefaultThemeLight = () => {
 export const ReferenceModeWithDefaultThemeSystem = () => {
   return (
     <Pathfinder
-      fetcherOptions={fetcherOptions}
+      fetcherOptions={ENV_API.fetcherOptions}
       themeOptions={{
         defaultTheme: 'system',
       }}
@@ -143,7 +197,7 @@ export const ReferenceModeWithDefaultThemeSystem = () => {
 export const ReferenceModeWithThemeOverrides = () => {
   return (
     <Pathfinder
-      fetcherOptions={fetcherOptions}
+      fetcherOptions={ENV_API.fetcherOptions}
       schemaPollingOptions={{
         enabled: true,
       }}
@@ -155,7 +209,7 @@ export const ReferenceModeWithThemeOverrides = () => {
 };
 
 export const IDEMode = () => {
-  return <Pathfinder mode="IDE" fetcherOptions={fetcherOptions} />;
+  return <Pathfinder mode="IDE" fetcherOptions={ENV_API.fetcherOptions} />;
 };
 
 export const IDEModeWithoutSchemaProps = () => {
@@ -163,7 +217,7 @@ export const IDEModeWithoutSchemaProps = () => {
 };
 
 export const ScoutMode = () => {
-  return <Pathfinder mode="SCOUT" fetcherOptions={fetcherOptions} />;
+  return <Pathfinder mode="SCOUT" fetcherOptions={ENV_API.fetcherOptions} />;
 };
 
 export const ScoutModeWithoutSchemaProps = () => {

--- a/packages/react/src/pathfinder/pathfinder.tsx
+++ b/packages/react/src/pathfinder/pathfinder.tsx
@@ -33,13 +33,15 @@ export const Pathfinder = ({
 
   const [isHydrated, setIsHydrated] = useState<boolean>(false);
 
-  useEffect(
-    () =>
-      uiStore.subscribe(({ isHydrated }) => {
-        setIsHydrated(isHydrated);
-      }),
-    [],
-  );
+  useEffect(() => {
+    uiStore.subscribe(({ isHydrated }) => {
+      setIsHydrated(isHydrated);
+    });
+
+    return () => {
+      cleanupStores();
+    };
+  }, []);
 
   useEffect(() => {
     // set the theme and handle overrides if provided
@@ -88,16 +90,7 @@ export const Pathfinder = ({
         }
       });
     }
-
-    return () => {
-      cleanupStores();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetcherOptions?.endpoint]);
-
-  if (!isHydrated) {
-    return null;
-  }
+  }, [fetcherOptions, schemaPollingOptions, themeOptions]);
 
   if (!fetcherOptions && !schema) {
     return (
@@ -105,6 +98,10 @@ export const Pathfinder = ({
         <Connect />
       </div>
     );
+  }
+
+  if (!isHydrated) {
+    return null;
   }
 
   if (fetcherOptions && !schema) {


### PR DESCRIPTION
This PR fixes an issue where, after props change, monaco editors are disposed. The effect where this cleanup function was running had props as dependencies, so this change relocates the cleanup function to an effect without dependencies.
