### PR TITLE
relocate top-level fontFamily assignment

### DIFF
--- a/packages/react/src/pathfinder/pathfinder.css.ts
+++ b/packages/react/src/pathfinder/pathfinder.css.ts
@@ -4,6 +4,7 @@ export const pathfinderClass = style({
   height: '100%',
   width: '100%',
   backgroundColor: contract.color.neutral[1],
+  fontFamily: contract.fonts.body,
 });
 
 export const connectWrapClass = style({

--- a/packages/style/src/theme/global.css.ts
+++ b/packages/style/src/theme/global.css.ts
@@ -1,15 +1,9 @@
 import { globalStyle } from '@vanilla-extract/css';
 
-import { contract } from './contract.css';
-
 import { HAIRLINE_BORDER_VAR } from '../constants';
 
 export const globalAllCSS = globalStyle('*', {
   boxSizing: 'border-box',
-});
-
-export const globalBodyCSS = globalStyle('body', {
-  fontFamily: contract.fonts.body,
 });
 
 export const globalRootCss = globalStyle(':root', {

--- a/packages/style/src/theme/index.ts
+++ b/packages/style/src/theme/index.ts
@@ -2,6 +2,6 @@ export { contract } from './contract.css';
 
 export { darkColors } from './dark.css';
 
-export { globalAllCSS, globalBodyCSS, globalRootCss } from './global.css';
+export { globalAllCSS, globalRootCss } from './global.css';
 
 export { lightColors } from './light.css';


### PR DESCRIPTION
This PR relocates the top-level fontFamily assignment from `body` to the Pathfinder component.