### PR TITLE
Make graphql a peer dependency

### DIFF
--- a/.changeset/heavy-stingrays-sparkle.md
+++ b/.changeset/heavy-stingrays-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@pathfinder-ide/shared": minor
+"@pathfinder-ide/stores": minor
+"@pathfinder-ide/react": minor
+---
+
+Make the graphql dependency a peer dependency

--- a/.changeset/heavy-stingrays-sparkle.md
+++ b/.changeset/heavy-stingrays-sparkle.md
@@ -1,7 +1,5 @@
 ---
-"@pathfinder-ide/shared": minor
-"@pathfinder-ide/stores": minor
-"@pathfinder-ide/react": minor
+'@pathfinder-ide/react': minor
 ---
 
 Make the graphql dependency a peer dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.18",
-    "graphql": "16.8.1",
     "idb-keyval": "6.2.1",
     "lodash": "^4.17.21",
     "monaco-editor": "0.40.0",
@@ -67,6 +66,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "graphql": ">=16.0.0"
   }
 }

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'graphql'],
       output: {
         format: 'esm',
         globals: {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,9 @@
     "@paralleldrive/cuid2": "^2.2.2",
     "@pathfinder-ide/eslint-config": "workspace:*",
     "@pathfinder-ide/tsconfig": "workspace:*",
-    "graphql": "16.8.1",
     "zustand": "4.4.7"
+  },
+  "peerDependencies": {
+    "graphql": ">=16.0.0"
   }
 }

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@pathfinder-ide/shared": "workspace:*",
     "@pathfinder-ide/style": "workspace:*",
-    "graphql": "16.8.1",
     "graphql-sse": "^2.3.0",
     "idb-keyval": "6.2.1",
     "lodash.merge": "^4.6.2",
@@ -24,5 +23,8 @@
     "@pathfinder-ide/tsconfig": "workspace:*",
     "@types/lodash.merge": "^4.6.7",
     "@types/lodash.update": "^4.10.7"
+  },
+  "peerDependencies": {
+    "graphql": ">=16.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,7 +280,7 @@ importers:
         specifier: 1.7.18
         version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
       graphql:
-        specifier: 16.8.1
+        specifier: '>=16.0.0'
         version: 16.8.1
       idb-keyval:
         specifier: 6.2.1
@@ -381,6 +381,10 @@ importers:
         version: 0.3.3(vitest@1.2.2)
 
   packages/shared:
+    dependencies:
+      graphql:
+        specifier: '>=16.0.0'
+        version: 16.8.1
     devDependencies:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
@@ -391,9 +395,6 @@ importers:
       '@pathfinder-ide/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      graphql:
-        specifier: 16.8.1
-        version: 16.8.1
       zustand:
         specifier: 4.4.7
         version: 4.4.7(@types/react@18.2.48)(react@18.2.0)
@@ -407,7 +408,7 @@ importers:
         specifier: workspace:*
         version: link:../style
       graphql:
-        specifier: 16.8.1
+        specifier: '>=16.0.0'
         version: 16.8.1
       graphql-sse:
         specifier: ^2.3.0


### PR DESCRIPTION
The graphql package does not work properly when it is included multiple times in an application.

Since Pathfinder is bundled, all control of the graphql package is out of the hands of the end user. If they try to import it themselves they will get an error thrown that there are multiple instances of graphql installed, and there's no way around it with overrides or other conventional methods for resolving troubles like this because of the bundling of the dependency.

Moving graphql to a peer dependency and marking it as an external dependency to vite ensures that the end user can fully control how graphql gets installed.

I set the peer dependency version to `>=16.0.0` to ensure the compatibility range is wide to have overlap with other libraries that depend on graphql as well, but if there are features of graphql that we rely on that were introduced in a later version this might have to be increased.
