### PR TITLE
Remove zIndex from active tab indicator

### DIFF
--- a/.changeset/ninety-zebras-shout.md
+++ b/.changeset/ninety-zebras-shout.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Remove zIndex from active tab indicator. The zIndex doesn't effect its visibility in the Pathfinder UI and this element tends to show in front of UI that is overlayed on top of Pathfinder when integrated in other applications.

--- a/packages/react/src/components/tabs/tabs.css.ts
+++ b/packages/react/src/components/tabs/tabs.css.ts
@@ -44,7 +44,6 @@ export const tabButtonClass = style([
         height: 2,
         bottom: 1,
         left: contract.space[12],
-        zIndex: 1,
       },
 
       '&[data-headlessui-state="selected"]': {


### PR DESCRIPTION
The zIndex doesn't effect its visibility in the Pathfinder UI and this element tends to show in front of UI that is overlayed on top of Pathfinder when integrated in other applications.

Closes GB-6070