### PR TITLE
fix: dont crash on spreads in operation root

### DIFF
--- a/.changeset/orange-onions-build.md
+++ b/.changeset/orange-onions-build.md
@@ -1,0 +1,5 @@
+---
+"@pathfinder-ide/react": patch
+---
+
+fix: dont crash on spreads in operation root

--- a/packages/react/src/compass/components/root-operation/root-operation.tsx
+++ b/packages/react/src/compass/components/root-operation/root-operation.tsx
@@ -1,4 +1,4 @@
-import { FieldNode, GraphQLFieldMap } from 'graphql';
+import { GraphQLFieldMap } from 'graphql';
 
 import type { AncestorRoot, AncestorsArray } from '../../compass-store';
 
@@ -41,7 +41,7 @@ export const RootOperation = ({
                 field: fields[field],
                 selection:
                   operationDefinition?.selectionSet?.selections.find(
-                    (s) => (s as FieldNode).name.value === fields[field].name,
+                    (s) => ("name" in s) ? s.name.value === fields[field].name : false
                   ) || null,
               },
             ]}


### PR DESCRIPTION
The `RootOperation` component was doing `(s as FieldNode).name` on the selections at the root of the current operation - which will cause "undefined is not an object" if one of the selections is an inline fragment.