### PR TITLE
update schema docs store to no longer require context provider

### DIFF
--- a/.changeset/few-hotels-cover.md
+++ b/.changeset/few-hotels-cover.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Refactors SchemaDocumentation to no longer require a context provider

--- a/packages/react/src/compass/compass.tsx
+++ b/packages/react/src/compass/compass.tsx
@@ -9,24 +9,15 @@ import { compassClass } from './compass.css';
 import { LoadingSchema, Tabs } from '../components';
 import { TabsProps } from '../components/tabs/tabs.types';
 
-import {
-  SchemaDocumentationStoreProvider,
-  useSchemaDocumentationStore,
-} from '../schema-documentation';
+import { useSchemaDocumenationStore } from '../schema-documentation';
 
 export const Compass = () => {
-  return (
-    <SchemaDocumentationStoreProvider>
-      <CompassComponent />
-    </SchemaDocumentationStoreProvider>
-  );
-};
-
-const CompassComponent = () => {
   // local state to control whether we should show the query or mutation tab
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
 
-  const { activeTertiaryPane } = useSchemaDocumentationStore();
+  const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
+  const clearTertiaryPaneStack =
+    useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
 
   const schema = useSchemaStore.use.schema();
 
@@ -52,6 +43,17 @@ const CompassComponent = () => {
     // "subscription"
     return setSelectedTabIndex(2);
   }, [operationDefinition, schema]);
+
+  useEffect(() => {
+    // clear tertiary stack when compass mounts and dismounts
+    clearTertiaryPaneStack();
+
+    return () => {
+      return clearTertiaryPaneStack();
+    };
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!schema) {
     return <LoadingSchema />;

--- a/packages/react/src/compass/components/details-actions/details-actions.tsx
+++ b/packages/react/src/compass/components/details-actions/details-actions.tsx
@@ -9,7 +9,7 @@ import { IconButton } from '../../../components/icon-button';
 
 import { type ListItemTypeTypes } from '../list-item';
 
-import { useSchemaDocumentationStore } from '../../../schema-documentation';
+import { useSchemaDocumenationStore } from '../../../schema-documentation';
 
 import { detailsActionsClass, detailsActionsControlsClass } from './details-actions.css';
 
@@ -26,7 +26,7 @@ export const DetailsActions = ({
   showActions = false,
   type,
 }: DetailsActionsProps) => {
-  const setActiveTertiaryPane = useSchemaDocumentationStore().setActiveTertiaryPane;
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
     <div

--- a/packages/react/src/compass/components/quick-docs/quick-docs.tsx
+++ b/packages/react/src/compass/components/quick-docs/quick-docs.tsx
@@ -1,9 +1,9 @@
-import { TertiaryPane, useSchemaDocumentationStore } from '../../../schema-documentation';
+import { TertiaryPane, useSchemaDocumenationStore } from '../../../schema-documentation';
 
 import { quickDocsClass } from './quick-docs.css';
 
 export const QuickDocs = () => {
-  const { activeTertiaryPane } = useSchemaDocumentationStore();
+  const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
 
   return (
     <div

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,7 +6,8 @@ export {
 
 export { Pathfinder } from './pathfinder';
 
+export { useSchemaDocumenationStore } from './schema-documentation/index';
+
 // schema-dependent components
 export { SchemaDocumentation } from './schema-documentation';
-
 export { SchemaView } from './schema-view';

--- a/packages/react/src/reference/reference.tsx
+++ b/packages/react/src/reference/reference.tsx
@@ -6,7 +6,7 @@ import { RecipeVariants, shared } from '@pathfinder-ide/style';
 
 import { Icon } from '../components';
 import { ConnectionBar } from '../components/connection-bar';
-import { SchemaDocumentation } from '../schema-documentation';
+import { SchemaDocumentation, useSchemaDocumenationStore } from '../schema-documentation';
 import { SchemaView } from '../schema-view';
 
 import { IconProps } from '../components/icon/icon.types';
@@ -45,6 +45,10 @@ const NavButton = ({
   visiblePane: AvailablePanes;
 }) => {
   const title = `View ${panesMap[paneName]}`;
+
+  const clearTertiaryPaneStack =
+    useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
+
   return (
     <button
       aria-label={title}
@@ -52,7 +56,10 @@ const NavButton = ({
       className={navigationButtonClass({
         isActive: visiblePane === paneName,
       })}
-      onClick={() => setVisiblePane(paneName)}
+      onClick={() => {
+        clearTertiaryPaneStack();
+        return setVisiblePane(paneName);
+      }}
     >
       <Icon name={iconName} size={'large'} />
     </button>

--- a/packages/react/src/schema-documentation/components/arguments-list/arguments-list.tsx
+++ b/packages/react/src/schema-documentation/components/arguments-list/arguments-list.tsx
@@ -2,7 +2,7 @@ import { GraphQLArgument, isInputObjectType } from 'graphql';
 
 import { unwrapType } from '@pathfinder-ide/shared';
 
-import { useSchemaDocumentationStore } from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { DefaultValue } from '../default-value';
 import { Delimiter } from '../delimiter';
@@ -23,7 +23,7 @@ export const ArgumentsList = ({
   showBorder?: boolean;
   showDescription?: boolean;
 }) => {
-  const { setActiveTertiaryPane } = useSchemaDocumentationStore();
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   if (args.length < 1) {
     return null;
@@ -37,7 +37,6 @@ export const ArgumentsList = ({
               showDescription,
             })}
             key={a.name}
-            data-testid="dsfsdfdsfdsf"
           >
             <div>
               {isInputObjectType(a.type) ? (

--- a/packages/react/src/schema-documentation/components/leaf/index.tsx
+++ b/packages/react/src/schema-documentation/components/leaf/index.tsx
@@ -10,7 +10,7 @@ import {
   GraphQLUnionType,
 } from 'graphql';
 
-import { useSchemaDocumentationStore } from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { ArgumentsList } from '../arguments-list';
 import {
@@ -66,7 +66,7 @@ export const LeafEnum = ({ type }: { type: GraphQLEnumType }) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const LeafField = ({ field }: { field: GraphQLField<any, any> }) => {
-  const { setActiveTertiaryPane } = useSchemaDocumentationStore();
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
     <>

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -1,10 +1,7 @@
 import { useEffect } from 'react';
 import { GraphQLSchema } from 'graphql';
 
-import {
-  SchemaDocumentationStoreProvider,
-  useSchemaDocumentationStore,
-} from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { initializeTheme, type ThemeOptions } from '@pathfinder-ide/stores';
 
@@ -36,24 +33,22 @@ export const SchemaDocumentation = ({
   schema,
   themeOptions,
 }: SchemaDocumentationProps) => {
-  return (
-    <SchemaDocumentationStoreProvider>
-      <SchemaDocumentationComponent schema={schema} themeOptions={themeOptions} />
-    </SchemaDocumentationStoreProvider>
-  );
-};
-
-const SchemaDocumentationComponent = ({
-  schema,
-  themeOptions,
-}: SchemaDocumentationProps) => {
-  const { activePrimaryPane, activeTertiaryPane, tertiaryPaneStack } =
-    useSchemaDocumentationStore();
+  const activePrimaryPane = useSchemaDocumenationStore.use.activePrimaryPane();
+  const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
+  const tertiaryPaneStack = useSchemaDocumenationStore.use.tertiaryPaneStack();
+  const clearTertiaryPaneStack =
+    useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
 
   useEffect(() => {
+    clearTertiaryPaneStack();
+
     // set the theme and handle overrides if provided
     initializeTheme({ options: themeOptions });
-  });
+
+    return () => {
+      return clearTertiaryPaneStack();
+    };
+  }, [clearTertiaryPaneStack, themeOptions]);
 
   if (!schema) {
     return <LoadingSchema />;

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import type { GraphQLDirective, GraphQLNamedType, GraphQLObjectType } from 'graphql';
 
-import { useSchemaDocumentationStore } from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { SortedTypeMap } from '../../types';
 
@@ -70,7 +70,8 @@ export const SecondaryPane = ({
   subscriptionRootType: GraphQLObjectType | null;
   sortedTypes: SortedTypeMap;
 }) => {
-  const { activePrimaryPane, activeTertiaryPane } = useSchemaDocumentationStore();
+  const activePrimaryPane = useSchemaDocumenationStore.use.activePrimaryPane();
+  const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
 
   let toRender: ReactElement = <></>;
 

--- a/packages/react/src/schema-documentation/components/summary/summary.tsx
+++ b/packages/react/src/schema-documentation/components/summary/summary.tsx
@@ -7,7 +7,7 @@ import type {
 
 import { unwrapType } from '@pathfinder-ide/shared';
 
-import { useSchemaDocumentationStore } from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { ArgumentsList } from '../arguments-list';
 import { DefaultValue } from '../default-value';
@@ -20,6 +20,7 @@ import {
   scalarArgumentNameClass,
   tertiaryTriggerButtonClass,
 } from '../../shared.styles.css';
+
 import { Delimiter } from '../delimiter';
 
 export const SummaryField = ({
@@ -30,7 +31,7 @@ export const SummaryField = ({
   field: GraphQLField<any, any, any>;
   resetTertiaryPaneOnClick: boolean;
 }) => {
-  const { setActiveTertiaryPane } = useSchemaDocumentationStore();
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
     <div className={summaryFieldClass}>
@@ -74,7 +75,7 @@ export const SummaryField = ({
 };
 
 export const SummaryInputField = ({ inputField }: { inputField: GraphQLInputField }) => {
-  const { setActiveTertiaryPane } = useSchemaDocumentationStore();
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
     <div className={summaryFieldClass}>
@@ -106,7 +107,7 @@ export const SummaryType = ({
   showDescription: boolean;
   type: GraphQLNamedType | GraphQLDirective;
 }) => {
-  const { setActiveTertiaryPane } = useSchemaDocumentationStore();
+  const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
     <div className={summaryTypeClass}>

--- a/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
@@ -11,8 +11,6 @@ import {
   isUnionType,
 } from 'graphql';
 
-import { useSchemaDocumentationStore } from '../../store';
-
 import {
   LeafScalar,
   LeafEnum,
@@ -37,13 +35,13 @@ import {
   tertiaryPaneNavButtonWrapClass,
 } from './tertiary-pane.css';
 
+import { useSchemaDocumenationStore } from '../../store';
+
 export const TertiaryPane = ({ pane }: { pane: TertiaryPaneType }) => {
-  const {
-    activeTertiaryPane,
-    clearTertiaryPaneStack,
-    navigateTertiaryPaneStack,
-    tertiaryPaneStack,
-  } = useSchemaDocumentationStore();
+  const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
+  const tertiaryPaneStack = useSchemaDocumenationStore.use.tertiaryPaneStack();
+  const { clearTertiaryPaneStack, navigateTertiaryPaneStack } =
+    useSchemaDocumenationStore.getState();
 
   if (!activeTertiaryPane) {
     return null;

--- a/packages/react/src/schema-documentation/components/type-system-nav-button/type-system-nav-button.tsx
+++ b/packages/react/src/schema-documentation/components/type-system-nav-button/type-system-nav-button.tsx
@@ -1,4 +1,4 @@
-import { useSchemaDocumentationStore } from '../../store';
+import { useSchemaDocumenationStore } from '../../store';
 
 import { Pill } from '../../../components';
 
@@ -15,8 +15,10 @@ export const TypeSystemNavButton = ({
   copy: string | React.ReactElement;
   count: string;
 }) => {
-  const { activePrimaryPane, setActivePrimaryPane, clearTertiaryPaneStack } =
-    useSchemaDocumentationStore();
+  const { setActivePrimaryPane, clearTertiaryPaneStack } =
+    useSchemaDocumenationStore.getState();
+
+  const activePrimaryPane = useSchemaDocumenationStore.use.activePrimaryPane();
 
   return (
     <button

--- a/packages/react/src/schema-documentation/index.ts
+++ b/packages/react/src/schema-documentation/index.ts
@@ -1,3 +1,3 @@
 export { SchemaDocumentation, TertiaryPane } from './components';
 
-export { SchemaDocumentationStoreProvider, useSchemaDocumentationStore } from './store';
+export { useSchemaDocumenationStore } from './store';

--- a/packages/react/src/schema-documentation/store/index.ts
+++ b/packages/react/src/schema-documentation/store/index.ts
@@ -1,4 +1,1 @@
-export {
-  SchemaDocumentationStoreProvider,
-  useSchemaDocumentationStore,
-} from './schema-documentation-store';
+export { useSchemaDocumenationStore } from './schema-documentation-store';

--- a/packages/react/src/schema-documentation/store/schema-documentation-store.tsx
+++ b/packages/react/src/schema-documentation/store/schema-documentation-store.tsx
@@ -1,6 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
-
-import { createStore, useStore } from 'zustand';
+import { createStore } from 'zustand';
 
 import { schemaDocumentationStoreActions } from './actions';
 import { schemaDocumentationState } from './state';
@@ -9,38 +7,15 @@ import {
   SchemaDocumentationStoreActions,
 } from './schema-documentation-store.types';
 
-const schemaDocumentationStore = () =>
-  createStore<SchemaDocumentationStoreState & SchemaDocumentationStoreActions>(
-    (set, get) => ({
-      ...schemaDocumentationState,
-      ...schemaDocumentationStoreActions(set, get),
-    }),
-  );
+const schemaDocumentationStore = createStore<
+  SchemaDocumentationStoreState & SchemaDocumentationStoreActions
+>()((set, get) => ({
+  ...schemaDocumentationState,
+  ...schemaDocumentationStoreActions(set, get),
+}));
 
-const SchemaDocumentationStoreContext = createContext<ReturnType<
-  typeof schemaDocumentationStore
-> | null>(null);
+import { createZustandSelectors } from '@pathfinder-ide/shared';
 
-export const SchemaDocumentationStoreProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
-  const store = useMemo(() => {
-    return schemaDocumentationStore();
-  }, []);
-
-  return (
-    <SchemaDocumentationStoreContext.Provider value={store}>
-      {children}
-    </SchemaDocumentationStoreContext.Provider>
-  );
-};
-
-export const useSchemaDocumentationStore = () => {
-  const store = useContext(SchemaDocumentationStoreContext);
-  if (store === null) {
-    throw new Error('Component must be wrapped in a SchemaDocumentationProvider');
-  }
-  return useStore(store);
-};
+export const useSchemaDocumenationStore = createZustandSelectors(
+  schemaDocumentationStore,
+);


### PR DESCRIPTION
This PR refactors the SchemaDocumentation components and store to no longer require a context provider wrapper. Additionally, this PR exports the `useSchemaDocumentationStore` hook so that it's available from the package,
