### PR TITLE
only clear tertiary stack when component unmounts

### DIFF
--- a/.changeset/empty-planets-doubt.md
+++ b/.changeset/empty-planets-doubt.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Fix tertiary nav stack clearing in SchemaDocs components

--- a/packages/react/src/compass/compass.tsx
+++ b/packages/react/src/compass/compass.tsx
@@ -45,12 +45,8 @@ export const Compass = () => {
   }, [operationDefinition, schema]);
 
   useEffect(() => {
-    // clear tertiary stack when compass mounts and dismounts
-    clearTertiaryPaneStack();
-
-    return () => {
-      return clearTertiaryPaneStack();
-    };
+    // clear tertiary stack when compass dismounts
+    return () => clearTertiaryPaneStack();
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -40,14 +40,10 @@ export const SchemaDocumentation = ({
     useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
 
   useEffect(() => {
-    clearTertiaryPaneStack();
-
     // set the theme and handle overrides if provided
     initializeTheme({ options: themeOptions });
 
-    return () => {
-      return clearTertiaryPaneStack();
-    };
+    return () => clearTertiaryPaneStack();
   }, [clearTertiaryPaneStack, themeOptions]);
 
   if (!schema) {


### PR DESCRIPTION
This PR fixes a bug in a previous PR where certain components clear the tertiary pane stack when they mount.
