### PR TITLE
remove automated clearing of tertiary pane stack

### DIFF
--- a/.changeset/dry-jokes-marry.md
+++ b/.changeset/dry-jokes-marry.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Fix: fully remove automated tertiaryPaneStack clearing in favor of manual clearing

--- a/packages/react/src/compass/compass.tsx
+++ b/packages/react/src/compass/compass.tsx
@@ -16,8 +16,6 @@ export const Compass = () => {
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
 
   const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
-  const clearTertiaryPaneStack =
-    useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
 
   const schema = useSchemaStore.use.schema();
 
@@ -43,13 +41,6 @@ export const Compass = () => {
     // "subscription"
     return setSelectedTabIndex(2);
   }, [operationDefinition, schema]);
-
-  useEffect(() => {
-    // clear tertiary stack when compass dismounts
-    return () => clearTertiaryPaneStack();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   if (!schema) {
     return <LoadingSchema />;

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -36,15 +36,11 @@ export const SchemaDocumentation = ({
   const activePrimaryPane = useSchemaDocumenationStore.use.activePrimaryPane();
   const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
   const tertiaryPaneStack = useSchemaDocumenationStore.use.tertiaryPaneStack();
-  const clearTertiaryPaneStack =
-    useSchemaDocumenationStore.getState().clearTertiaryPaneStack;
 
   useEffect(() => {
     // set the theme and handle overrides if provided
     initializeTheme({ options: themeOptions });
-
-    return () => clearTertiaryPaneStack();
-  }, [clearTertiaryPaneStack, themeOptions]);
+  }, [themeOptions]);
 
   if (!schema) {
     return <LoadingSchema />;


### PR DESCRIPTION
This PR removes all automated clearing of the tertiary pane stack in favor of manually calling `clearTertiaryPaneStack` when necessary.
