### PR TITLE
add tertiaryPaneFieldSlotComponent prop

### DIFF
--- a/.changeset/clean-cycles-rush.md
+++ b/.changeset/clean-cycles-rush.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Adds a prop (tertiaryPaneFieldSlotComponent) to the SchemaDocumentation component that accepts a ReactNode to be displayed in the TertiaryPane component when a field pane is active

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 import { GraphQLSchema } from 'graphql';
 
 import { useSchemaDocumenationStore } from '../../store';
@@ -27,11 +27,13 @@ import { sharedPaneClass } from '../../shared.styles.css';
 type SchemaDocumentationProps = {
   schema?: GraphQLSchema;
   themeOptions?: Partial<ThemeOptions>;
+  tertiaryPaneFieldSlotComponent?: ReactNode;
 };
 
 export const SchemaDocumentation = ({
   schema,
   themeOptions,
+  tertiaryPaneFieldSlotComponent,
 }: SchemaDocumentationProps) => {
   const activePrimaryPane = useSchemaDocumenationStore.use.activePrimaryPane();
   const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
@@ -148,7 +150,10 @@ export const SchemaDocumentation = ({
                   component: (
                     <>
                       {activeTertiaryPane && (
-                        <TertiaryPane pane={activeTertiaryPane['pane']} />
+                        <TertiaryPane
+                          pane={activeTertiaryPane['pane']}
+                          fieldSlotComponent={tertiaryPaneFieldSlotComponent || undefined}
+                        />
                       )}
                     </>
                   ),

--- a/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 import {
   isDirective,
@@ -37,7 +37,13 @@ import {
 
 import { useSchemaDocumenationStore } from '../../store';
 
-export const TertiaryPane = ({ pane }: { pane: TertiaryPaneType }) => {
+export const TertiaryPane = ({
+  pane,
+  fieldSlotComponent,
+}: {
+  pane: TertiaryPaneType;
+  fieldSlotComponent?: ReactNode;
+}) => {
   const activeTertiaryPane = useSchemaDocumenationStore.use.activeTertiaryPane();
   const tertiaryPaneStack = useSchemaDocumenationStore.use.tertiaryPaneStack();
   const { clearTertiaryPaneStack, navigateTertiaryPaneStack } =
@@ -90,7 +96,12 @@ export const TertiaryPane = ({ pane }: { pane: TertiaryPaneType }) => {
 
   if (activeTertiaryPane && 'args' in pane && !isDirective(pane)) {
     leadType = 'Field';
-    toRender = <LeafField field={pane} />;
+    toRender = (
+      <>
+        <LeafField field={pane} />
+        {fieldSlotComponent && fieldSlotComponent}
+      </>
+    );
   }
 
   return (

--- a/packages/react/src/schema-documentation/schema-documentation.stories.tsx
+++ b/packages/react/src/schema-documentation/schema-documentation.stories.tsx
@@ -1,4 +1,4 @@
-import { GraphQLSchema, printSchema } from 'graphql';
+import { printSchema } from 'graphql';
 import { useState, useEffect } from 'react';
 import { SchemaView } from '../schema-view';
 import { SchemaDocumentation } from './components/schema-documentation';
@@ -34,6 +34,15 @@ export const WithSchemaAndThemeOptions = () => {
 
 export const WithSchema = () => {
   return <SchemaDocumentation schema={testSchema} />;
+};
+
+export const WithSchemaAndTertiaryPaneFieldSlotComponent = () => {
+  return (
+    <SchemaDocumentation
+      schema={testSchema}
+      tertiaryPaneFieldSlotComponent={<>I'm a tertiaryPaneFieldSlotComponent!</>}
+    />
+  );
 };
 
 export const WithDelayedSchema = () => {


### PR DESCRIPTION
This PR adds a prop (`tertiaryPaneFieldSlotComponent`) to the SchemaDocumentation component that accepts a ReactNode to be displayed in the TertiaryPane component when a `field` pane is active.
