### PR TITLE
add parent GraphQLObject to GraphQLField tertiary panes

### DIFF
--- a/.changeset/sixty-squids-learn.md
+++ b/.changeset/sixty-squids-learn.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Add parent ObjectType info to tertiary panes of type GraphQLField

--- a/packages/react/src/schema-documentation/components/leaf/index.tsx
+++ b/packages/react/src/schema-documentation/components/leaf/index.tsx
@@ -64,8 +64,14 @@ export const LeafEnum = ({ type }: { type: GraphQLEnumType }) => {
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const LeafField = ({ field }: { field: GraphQLField<any, any> }) => {
+export const LeafField = ({
+  field,
+  parentType,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  field: GraphQLField<any, any>;
+  parentType?: GraphQLObjectType;
+}) => {
   const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
 
   return (
@@ -75,7 +81,7 @@ export const LeafField = ({ field }: { field: GraphQLField<any, any> }) => {
         <button
           className={returnTypeButtonClass}
           onClick={() =>
-            setActiveTertiaryPane({ destinationPane: unwrapType(field.type) })
+            setActiveTertiaryPane({ destinationPane: unwrapType(field.type), parentType })
           }
         >
           {field.type.toString()}
@@ -117,7 +123,7 @@ export const LeafObject = ({ type }: { type: GraphQLObjectType }) => {
   return (
     <>
       <SectionDescription description={type.description} />
-      <SectionFields fields={fields} resetTertiaryPaneOnClick={false} />
+      <SectionFields fields={fields} parentType={type} resetTertiaryPaneOnClick={false} />
       <SectionInterface interfaces={interfaces} />
     </>
   );

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -52,7 +52,11 @@ const RootOperationDetails = ({
         <Markdown content={rootOperationType.name} />
       </Section>
       <SectionDescription description={rootOperationType.description} />
-      <SectionFields fields={fields} resetTertiaryPaneOnClick={true} />
+      <SectionFields
+        fields={fields}
+        parentType={rootOperationType}
+        resetTertiaryPaneOnClick={true}
+      />
     </>
   );
 };

--- a/packages/react/src/schema-documentation/components/section/index.tsx
+++ b/packages/react/src/schema-documentation/components/section/index.tsx
@@ -73,10 +73,12 @@ export const SectionEnumValues = ({
 
 export const SectionFields = ({
   fields,
+  parentType,
   resetTertiaryPaneOnClick,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fields: GraphQLFieldMap<any, any>;
+  parentType?: GraphQLObjectType;
   resetTertiaryPaneOnClick: boolean;
 }) => {
   return (
@@ -89,6 +91,7 @@ export const SectionFields = ({
               <SummaryField
                 key={fields[f].name}
                 field={fields[f]}
+                parentType={parentType}
                 resetTertiaryPaneOnClick={resetTertiaryPaneOnClick}
               />
             ))}

--- a/packages/react/src/schema-documentation/components/summary/summary.tsx
+++ b/packages/react/src/schema-documentation/components/summary/summary.tsx
@@ -3,6 +3,7 @@ import type {
   GraphQLField,
   GraphQLInputField,
   GraphQLNamedType,
+  GraphQLObjectType,
 } from 'graphql';
 
 import { unwrapType } from '@pathfinder-ide/shared';
@@ -25,10 +26,12 @@ import { Delimiter } from '../delimiter';
 
 export const SummaryField = ({
   field,
+  parentType,
   resetTertiaryPaneOnClick,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   field: GraphQLField<any, any, any>;
+  parentType?: GraphQLObjectType;
   resetTertiaryPaneOnClick: boolean;
 }) => {
   const { setActiveTertiaryPane } = useSchemaDocumenationStore.getState();
@@ -42,6 +45,7 @@ export const SummaryField = ({
         onClick={() =>
           setActiveTertiaryPane({
             destinationPane: field,
+            parentType,
             reset: resetTertiaryPaneOnClick,
           })
         }

--- a/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
@@ -98,7 +98,7 @@ export const TertiaryPane = ({
     leadType = 'Field';
     toRender = (
       <>
-        <LeafField field={pane} />
+        <LeafField field={pane} parentType={activeTertiaryPane.parentType} />
         {fieldSlotComponent && fieldSlotComponent}
       </>
     );

--- a/packages/react/src/schema-documentation/store/actions.ts
+++ b/packages/react/src/schema-documentation/store/actions.ts
@@ -4,6 +4,7 @@ import {
   GetSchemaDocumentationStore,
   SetSchemaDocumentationStore,
   SchemaDocumentationStoreActions,
+  TertiaryPaneStackItem,
 } from './schema-documentation-store.types';
 
 export const schemaDocumentationStoreActions = (
@@ -28,11 +29,15 @@ export const schemaDocumentationStoreActions = (
       tertiaryPaneStack: tertiaryPaneStack.slice(0, destinationPaneIndex + 1),
     });
   },
-  setActiveTertiaryPane: ({ destinationPane, reset = false }) => {
+  setActiveTertiaryPane: ({ destinationPane, parentType, reset = false }) => {
     // generate a unique id for our pane
     const paneHash = generateCuid({});
 
-    const pane = { hash: paneHash, pane: destinationPane };
+    const pane: TertiaryPaneStackItem = {
+      hash: paneHash,
+      pane: destinationPane,
+      parentType,
+    };
     if (reset) {
       set({
         activeTertiaryPane: pane,

--- a/packages/react/src/schema-documentation/store/schema-documentation-store.types.ts
+++ b/packages/react/src/schema-documentation/store/schema-documentation-store.types.ts
@@ -1,8 +1,14 @@
 import { StoreApi } from 'zustand';
 
 import { TertiaryPaneType, TopLevelPane } from '../types';
+import { GraphQLObjectType } from 'graphql';
 
-type TertiaryPaneStackItem = { hash: string; pane: TertiaryPaneType };
+export type TertiaryPaneStackItem = {
+  hash: string;
+  pane: TertiaryPaneType;
+  /** For TertiaryPaneType of GraphQLField, we'll provide the parent type */
+  parentType?: GraphQLObjectType;
+};
 
 export type SchemaDocumentationStoreActions = {
   setActivePrimaryPane: ({ destinationPane }: { destinationPane: TopLevelPane }) => void;
@@ -14,9 +20,11 @@ export type SchemaDocumentationStoreActions = {
   }) => void;
   setActiveTertiaryPane: ({
     destinationPane,
+    parentType,
     reset,
   }: {
     destinationPane: TertiaryPaneType;
+    parentType?: GraphQLObjectType;
     reset?: boolean;
   }) => void;
 };


### PR DESCRIPTION
This PR adds additional info about the parent object type for tertiary panes that display a field.
