### PR TITLE
Allow for externalizing monaco editor dependency

### DIFF
--- a/.changeset/tasty-ducks-study.md
+++ b/.changeset/tasty-ducks-study.md
@@ -1,6 +1,5 @@
 ---
 '@pathfinder-ide/react': minor
-'@pathfinder-ide/stores': patch
 ---
 
 Add a 'lite' variant to pathfinder-ide/react that doesn't include monaco-editor by default and allow the user to supply the monaco instance from his project

--- a/.changeset/tasty-ducks-study.md
+++ b/.changeset/tasty-ducks-study.md
@@ -1,0 +1,6 @@
+---
+'@pathfinder-ide/react': minor
+'@pathfinder-ide/stores': patch
+---
+
+Add a 'lite' variant to pathfinder-ide/react that doesn't include monaco-editor by default and allow the user to supply the monaco instance from his project

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node", "./vite-env.d.ts"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/desktop/vite-env.d.ts
+++ b/apps/desktop/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMeta {
+  readonly __IS_LITE_MODE_?: string;
+}

--- a/apps/ladle/.ladle/components.tsx
+++ b/apps/ladle/.ladle/components.tsx
@@ -8,6 +8,9 @@ import { ThemeSwitcher } from '../../../packages/react/src/components/theme-swit
 import './styles.css';
 
 import { contract } from '@pathfinder-ide/style';
+import { setMonacoImporter } from '../../../packages/stores/src';
+
+setMonacoImporter(() => import('monaco-graphql/esm/monaco-editor'));
 
 export const Provider: GlobalProvider = ({ children, globalState }) => {
   return (

--- a/apps/ladle/package.json
+++ b/apps/ladle/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@ladle/react": "4.0.2",
+    "monaco-editor": "0.40.0",
+    "monaco-graphql": "1.3.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,3 +1,3 @@
 # workers
 *.worker.bundle.js
-
+lite-dist

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     "build:lite": "vite build --config vite.lite.config.ts",
     "build": "pnpm run build:lite && pnpm run build:full",
     "lint": "eslint .",
-    "test:once": "vitest run",
+    "test:once": "vitest run --config vite.config.ts",
     "test:watch": "vitest",
     "types": "tsc --noEmit"
   },
@@ -63,9 +63,9 @@
     "fake-indexeddb": "5.0.2",
     "jsdom": "22.1.0",
     "ts-node": "^10.9.1",
-    "vite": "5.0.12",
-    "vite-plugin-dts": "3.6.4",
-    "vitest": "1.2.2",
+    "vite": "5.4.2",
+    "vite-plugin-dts": "4.1.0",
+    "vitest": "2.0.5",
     "vitest-canvas-mock": "0.3.3"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,17 +13,21 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "lite-dist"
   ],
   "module": "./dist/pathfinder.es.js",
   "types": "./dist/pathfinder.es.d.ts",
   "exports": {
     ".": "./dist/pathfinder.es.js",
+    "./lite": "./lite-dist/pathfinder.es.js",
     "./dist/style.css": "./dist/style.css"
   },
   "scripts": {
     "build:workers": "ts-node ./workers/build-workers.js",
-    "build": "pnpm run build:workers && vite build",
+    "build:full": "pnpm run build:workers && vite build",
+    "build:lite": "vite build --config vite.lite.config.ts",
+    "build": "pnpm run build:lite && pnpm run build:full",
     "lint": "eslint .",
     "test:once": "vitest run",
     "test:watch": "vitest",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@
 export {
   setTheme as setPathfinderTheme,
   useThemeStore as usePathfinderThemeStore,
+  setMonacoImporter,
 } from '@pathfinder-ide/stores';
 
 export { Pathfinder } from './pathfinder';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
+import { setMonacoImporter } from '@pathfinder-ide/stores';
+
 // store functions
 export {
   setTheme as setPathfinderTheme,
@@ -12,3 +14,7 @@ export { useSchemaDocumenationStore } from './schema-documentation/index';
 // schema-dependent components
 export { SchemaDocumentation } from './schema-documentation';
 export { SchemaView } from './schema-view';
+
+if (import.meta.__IS_LITE_MODE_ !== 'true') {
+  setMonacoImporter(() => import('monaco-graphql/esm/monaco-editor'));
+}

--- a/packages/react/src/pathfinder/pathfinder.test.tsx
+++ b/packages/react/src/pathfinder/pathfinder.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
 import { Pathfinder } from './pathfinder';
 import { setTheme, themeStore } from '@pathfinder-ide/stores';
 import { testSchema } from '@pathfinder-ide/stores/src/schema-store/test-schema';
@@ -28,21 +29,22 @@ const overrides = {
 };
 
 describe('Pathfinder props', () => {
-  it('should correctly render Welcome when Pathfinder does not receive fetcherOptions', async () => {
+  it('should correctly render Welcome when Pathfinder does not receive fetcherOptions', () => {
     render(<Pathfinder />);
 
     const welcomeContainer = screen.getByTestId('welcome-container');
+
     expect(welcomeContainer).toBeInTheDocument();
   });
 
-  it('should correctly render Pathfinder without theme override props', async () => {
+  it('should correctly render Pathfinder without theme override props', () => {
     render(<Pathfinder fetcherOptions={{ endpoint: 'ENDPOINT' }} />);
 
     const themeOverrides = themeStore.getState().themeOverrides;
     expect(themeOverrides).toBe(null);
   });
 
-  it('should correctly render Pathfinder with theme override props', async () => {
+  it('should correctly render Pathfinder with theme override props', () => {
     render(
       <Pathfinder
         fetcherOptions={{ endpoint: 'ENDPOINT' }}

--- a/packages/react/src/pathfinder/pathfinder.test.tsx
+++ b/packages/react/src/pathfinder/pathfinder.test.tsx
@@ -3,6 +3,12 @@ import { Pathfinder } from './pathfinder';
 import { setTheme, themeStore } from '@pathfinder-ide/stores';
 import { testSchema } from '@pathfinder-ide/stores/src/schema-store/test-schema';
 
+import { setMonacoImporter } from '../../../stores/src';
+
+beforeAll(() => {
+  setMonacoImporter(() => import('monaco-graphql/esm/monaco-editor'));
+});
+
 const overrides = {
   dark: {
     color: {

--- a/packages/react/src/pathfinder/pathfinder.tsx
+++ b/packages/react/src/pathfinder/pathfinder.tsx
@@ -36,12 +36,13 @@ export const Pathfinder = ({
   const [isHydrated, setIsHydrated] = useState<boolean>(false);
 
   useEffect(() => {
-    uiStore.subscribe(({ isHydrated }) => {
+    const unsub = uiStore.subscribe(({ isHydrated }) => {
       setIsHydrated(isHydrated);
     });
 
     return () => {
       cleanupStores();
+      unsub();
     };
   }, []);
 

--- a/packages/react/vite-env.d.ts
+++ b/packages/react/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+/// <reference types="react/canary" />
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  VITE_LITE_MODE?: string;
+}

--- a/packages/react/vite-env.d.ts
+++ b/packages/react/vite-env.d.ts
@@ -2,5 +2,10 @@
 /// <reference types="react/canary" />
 interface ImportMetaEnv {
   readonly DEV: boolean;
-  VITE_LITE_MODE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+
+  readonly __IS_LITE_MODE_?: string;
 }

--- a/packages/react/vite.lite.config.ts
+++ b/packages/react/vite.lite.config.ts
@@ -1,0 +1,46 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vitest/config';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import dts from 'vite-plugin-dts';
+import pluginReact from '@vitejs/plugin-react';
+
+process.env.LITE_MODE = 'true';
+
+export default defineConfig({
+  // 👇 https://github.com/vitejs/vite/issues/11943#issuecomment-1419293906
+  base: './',
+  build: {
+    target: 'ESNext',
+    outDir: 'lite-dist',
+    lib: {
+      entry: 'src/index.ts',
+      name: 'pathfinder',
+      fileName: (format) => `pathfinder.${format}.js`,
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'graphql', 'monaco-editor', 'monaco-graphql'],
+      output: {
+        format: 'esm',
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
+  },
+  plugins: [
+    dts({
+      rollupTypes: true,
+      exclude: ['./test'],
+    }),
+    pluginReact(),
+    vanillaExtractPlugin({}),
+  ],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/packages/react/vite.lite.config.ts
+++ b/packages/react/vite.lite.config.ts
@@ -1,47 +1,17 @@
 /// <reference types="vitest" />
 
-import { defineConfig } from 'vitest/config';
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
-import dts from 'vite-plugin-dts';
-import pluginReact from '@vitejs/plugin-react';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import defaultConfig from './vite.config';
 
-export default defineConfig({
-  // 👇 https://github.com/vitejs/vite/issues/11943#issuecomment-1419293906
-  base: './',
+const overrideConfig = defineConfig({
   define: {
     'import.meta.__IS_LITE_MODE_': 'true',
   },
   build: {
-    target: 'ESNext',
-    outDir: 'lite-dist',
-    lib: {
-      entry: 'src/index.ts',
-      name: 'pathfinder',
-      fileName: (format) => `pathfinder.${format}.js`,
-      formats: ['es'],
-    },
     rollupOptions: {
-      external: ['react', 'react-dom', 'graphql', /^monaco-editor(\/.*)?/],
-      output: {
-        format: 'esm',
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-        },
-      },
+      external: [/^monaco-editor(\/.*)?/],
     },
-  },
-  plugins: [
-    dts({
-      rollupTypes: true,
-      exclude: ['./test'],
-    }),
-    pluginReact(),
-    vanillaExtractPlugin({}),
-  ],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
   },
 });
+
+export default mergeConfig(defaultConfig, overrideConfig);

--- a/packages/react/vite.lite.config.ts
+++ b/packages/react/vite.lite.config.ts
@@ -8,6 +8,7 @@ const overrideConfig = defineConfig({
     'import.meta.__IS_LITE_MODE_': 'true',
   },
   build: {
+    outDir: 'lite-dist',
     rollupOptions: {
       external: [/^monaco-editor(\/.*)?/],
     },

--- a/packages/react/vite.lite.config.ts
+++ b/packages/react/vite.lite.config.ts
@@ -5,11 +5,12 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import dts from 'vite-plugin-dts';
 import pluginReact from '@vitejs/plugin-react';
 
-process.env.LITE_MODE = 'true';
-
 export default defineConfig({
   // 👇 https://github.com/vitejs/vite/issues/11943#issuecomment-1419293906
   base: './',
+  define: {
+    'import.meta.__IS_LITE_MODE_': 'true',
+  },
   build: {
     target: 'ESNext',
     outDir: 'lite-dist',
@@ -20,7 +21,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'graphql', 'monaco-editor', 'monaco-graphql'],
+      external: ['react', 'react-dom', 'graphql', /^monaco-editor(\/.*)?/],
       output: {
         format: 'esm',
         globals: {

--- a/packages/stores/src/index.ts
+++ b/packages/stores/src/index.ts
@@ -16,6 +16,7 @@ export {
   runExecuteOperation,
   setMonacoEditorTheme,
   useMonacoEditorStore,
+  setMonacoImporter,
 } from './monaco-editor-store';
 
 export type {

--- a/packages/stores/src/monaco-editor-store/actions/create-monaco-editor.ts
+++ b/packages/stores/src/monaco-editor-store/actions/create-monaco-editor.ts
@@ -16,6 +16,7 @@ import { monacoEditorStore } from '../../monaco-editor-store';
 import { getMonacoEditor } from './get-monaco-editor';
 
 import { initializeMonacoEditor } from './initialize-monaco-editor';
+import { importMonaco } from './monaco-import';
 
 export const createMonacoEditor: MonacoEditorStoreActions['createMonacoEditor'] = async ({
   defaultValue,
@@ -24,7 +25,7 @@ export const createMonacoEditor: MonacoEditorStoreActions['createMonacoEditor'] 
   monacoOptionOverrides,
   ref,
 }) => {
-  const { editor, Uri } = await import('monaco-graphql/esm/monaco-editor');
+  const { editor, Uri } = await importMonaco();
 
   // initialize if necessary
   if (!monacoEditorStore.getState().isInitialized) {

--- a/packages/stores/src/monaco-editor-store/actions/index.ts
+++ b/packages/stores/src/monaco-editor-store/actions/index.ts
@@ -11,3 +11,5 @@ export { pushMonacoEditorEdit } from './push-monaco-editor-edit';
 export { runExecuteOperation } from './run-execute-operation';
 
 export { setMonacoEditorTheme } from './set-monaco-editor-theme';
+
+export { setMonacoImporter } from './monaco-import';

--- a/packages/stores/src/monaco-editor-store/actions/initialize-monaco-editor.ts
+++ b/packages/stores/src/monaco-editor-store/actions/initialize-monaco-editor.ts
@@ -2,11 +2,12 @@ import { themeStore } from '../../theme-store';
 import { editorTheme } from '../helpers/editor-theme';
 import { monacoEditorStore } from '../monaco-editor-store';
 import { MonacoEditorStoreActions } from '../monaco-editor-store.types';
+import { importMonaco } from './monaco-import';
 import { setMonacoEditorTheme } from './set-monaco-editor-theme';
 
 export const initializeMonacoEditor: MonacoEditorStoreActions['initializeMonacoEditor'] =
   async () => {
-    const { editor } = await import('monaco-graphql/esm/monaco-editor');
+    const { editor } = await importMonaco();
 
     const activeTheme = themeStore.getState().activeTheme;
 

--- a/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
+++ b/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
@@ -15,6 +15,21 @@ export function importMonaco() {
 
 let importFn: null | (() => Promise<typeof import('monaco-editor')>) = null;
 
+/**
+ * Sets the importer function for the 'monaco-editor' module.
+ *
+ * @param dynamicImport - a function that returns a promise that resolves to the 'monaco-editor' module.
+ *
+ * @remarks
+ * Only use this function if you are using `pathfinder-ide/react/lite`.
+ *
+ * @example
+ * ```tsx
+ * import { setMonacoImporter } from '@pathfinder-ide/stores';
+ *
+ * setMonacoImporter(() => import('monaco-graphql/esm/monaco-editor'));
+ * ```
+ */
 export function setMonacoImporter(
   dynamicImport: () => Promise<typeof import('monaco-editor')>,
 ) {

--- a/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
+++ b/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
@@ -1,0 +1,16 @@
+const { promise, resolve, reject } =
+  Promise.withResolvers<typeof import('monaco-editor')>();
+
+export function importMonaco() {
+  return promise;
+}
+
+export function setMonacoImporter(
+  dynamicImport: Promise<{ default: typeof import('monaco-editor') }>,
+) {
+  return dynamicImport
+    .then(({ default: monacoPackage }) => {
+      resolve(monacoPackage);
+    })
+    .catch(reject);
+}

--- a/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
+++ b/packages/stores/src/monaco-editor-store/actions/monaco-import.ts
@@ -5,12 +5,21 @@ export function importMonaco() {
   return promise;
 }
 
+let isImporterSet = false;
+
 export function setMonacoImporter(
   dynamicImport: Promise<{ default: typeof import('monaco-editor') }>,
 ) {
-  return dynamicImport
+  if (isImporterSet) return;
+
+  isImporterSet = true;
+  dynamicImport
     .then(({ default: monacoPackage }) => {
       resolve(monacoPackage);
     })
     .catch(reject);
+}
+
+if (process.env.LITE_MODE !== 'true') {
+  setMonacoImporter(import('monaco-graphql/esm/monaco-editor'));
 }

--- a/packages/stores/src/monaco-editor-store/actions/set-monaco-editor-theme.ts
+++ b/packages/stores/src/monaco-editor-store/actions/set-monaco-editor-theme.ts
@@ -1,9 +1,10 @@
 import { monacoEditorStore } from '../monaco-editor-store';
 import { MonacoEditorStoreActions } from '../monaco-editor-store.types';
+import { importMonaco } from './monaco-import';
 
 export const setMonacoEditorTheme: MonacoEditorStoreActions['setMonacoEditorTheme'] =
   async ({ theme }) => {
-    const { editor } = await import('monaco-graphql/esm/monaco-editor');
+    const { editor } = await importMonaco();
     const isInitialized = monacoEditorStore.getState().isInitialized;
 
     if (!isInitialized) {

--- a/packages/stores/src/monaco-editor-store/helpers/editor-theme.ts
+++ b/packages/stores/src/monaco-editor-store/helpers/editor-theme.ts
@@ -56,6 +56,7 @@ export const editorTheme = ({
     // if you're developing, it's fun to set this to "#FF0000" (RED) to see non-tokenized bits
     'editor.foreground': colorsForEditor[variant].ui_neutral06, // Editor default foreground color.
     'editorCursor.foreground': colorsForEditor[variant].yellow, // Color of the editor cursor.
+    focusBorder: '#ff000000',
     // background color for selected text within the editor, set to one scale step above the base
     'editor.selectionBackground': colorsForEditor[variant].ui_neutral02,
     'editor.background': '#FFFFFF00', // white with a 00 alpha value

--- a/packages/stores/src/monaco-editor-store/index.ts
+++ b/packages/stores/src/monaco-editor-store/index.ts
@@ -5,6 +5,7 @@ export {
   pushMonacoEditorEdit,
   runExecuteOperation,
   setMonacoEditorTheme,
+  setMonacoImporter,
 } from './actions';
 
 export { monacoEditorStore } from './monaco-editor-store';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,12 @@ importers:
       '@ladle/react':
         specifier: 4.0.2
         version: 4.0.2(@swc/helpers@0.5.2)(@types/node@20.14.10)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.2)
+      monaco-editor:
+        specifier: 0.40.0
+        version: 0.40.0
+      monaco-graphql:
+        specifier: 1.3.0
+        version: 1.3.0(graphql@16.9.0)(monaco-editor@0.40.0)(prettier@3.3.3)
       react:
         specifier: 18.3.1
         version: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,7 +337,7 @@ importers:
         version: link:../tsconfig
       '@testing-library/jest-dom':
         specifier: 6.4.6
-        version: 6.4.6(@types/jest@29.5.12)(vitest@1.2.2(@types/node@20.14.10)(jsdom@22.1.0))
+        version: 6.4.6(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.14.10)(jsdom@22.1.0))
       '@testing-library/react':
         specifier: 14.3.1
         version: 14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -364,10 +364,10 @@ importers:
         version: 0.5.3(@vanilla-extract/css@1.14.2)
       '@vanilla-extract/vite-plugin':
         specifier: 3.9.5
-        version: 3.9.5(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2))(vite@5.0.12(@types/node@20.14.10))
+        version: 3.9.5(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2))(vite@5.4.2(@types/node@20.14.10))
       '@vitejs/plugin-react':
         specifier: 4.3.1
-        version: 4.3.1(vite@5.0.12(@types/node@20.14.10))
+        version: 4.3.1(vite@5.4.2(@types/node@20.14.10))
       esbuild:
         specifier: 0.23.0
         version: 0.23.0
@@ -381,17 +381,17 @@ importers:
         specifier: ^10.9.1
         version: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2)
       vite:
-        specifier: 5.0.12
-        version: 5.0.12(@types/node@20.14.10)
+        specifier: 5.4.2
+        version: 5.4.2(@types/node@20.14.10)
       vite-plugin-dts:
-        specifier: 3.6.4
-        version: 3.6.4(@types/node@20.14.10)(rollup@4.18.1)(typescript@5.4.2)(vite@5.0.12(@types/node@20.14.10))
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@20.14.10)(rollup@4.21.2)(typescript@5.4.2)(vite@5.4.2(@types/node@20.14.10))
       vitest:
-        specifier: 1.2.2
-        version: 1.2.2(@types/node@20.14.10)(jsdom@22.1.0)
+        specifier: 2.0.5
+        version: 2.0.5(@types/node@20.14.10)(jsdom@22.1.0)
       vitest-canvas-mock:
         specifier: 0.3.3
-        version: 0.3.3(vitest@1.2.2(@types/node@20.14.10)(jsdom@22.1.0))
+        version: 0.3.3(vitest@2.0.5(@types/node@20.14.10)(jsdom@22.1.0))
 
   packages/shared:
     dependencies:
@@ -1604,11 +1604,11 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@microsoft/api-extractor-model@7.29.2':
-    resolution: {integrity: sha512-hAYajOjQan3uslhKJRwvvHIdLJ+ZByKqdSsJ/dgHFxPtEbdKpzMDO8zuW4K5gkSMYl5D0LbNwxkhxr51P2zsmw==}
+  '@microsoft/api-extractor-model@7.29.4':
+    resolution: {integrity: sha512-LHOMxmT8/tU1IiiiHOdHFF83Qsi+V8d0kLfscG4EvQE9cafiR8blOYr8SfkQKWB1wgEilQgXJX3MIA4vetDLZw==}
 
-  '@microsoft/api-extractor@7.47.0':
-    resolution: {integrity: sha512-LT8yvcWNf76EpDC+8/ArTVSYePvuDQ+YbAUrsTcpg3ptiZ93HIcMCozP/JOxDt+rrsFfFHcpfoselKfPyRI0GQ==}
+  '@microsoft/api-extractor@7.47.4':
+    resolution: {integrity: sha512-HKm+P4VNzWwvq1Ey+Jfhhj/3MjsD+ka2hbt8L5AcRM95lu1MFOYnz3XlU7Gr79Q/ZhOb7W/imAKeYrOI0bFydg==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.17.0':
@@ -1741,8 +1741,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.21.2':
+    resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.18.1':
     resolution: {integrity: sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.21.2':
+    resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
     cpu: [arm64]
     os: [android]
 
@@ -1751,8 +1761,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.21.2':
+    resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.18.1':
     resolution: {integrity: sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.21.2':
+    resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
     cpu: [x64]
     os: [darwin]
 
@@ -1761,8 +1781,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
+    resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     resolution: {integrity: sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
+    resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
     cpu: [arm]
     os: [linux]
 
@@ -1771,8 +1801,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.21.2':
+    resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.18.1':
     resolution: {integrity: sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.21.2':
+    resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
     cpu: [arm64]
     os: [linux]
 
@@ -1781,8 +1821,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
+    resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     resolution: {integrity: sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
+    resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
     cpu: [riscv64]
     os: [linux]
 
@@ -1791,8 +1841,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.21.2':
+    resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     resolution: {integrity: sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.21.2':
+    resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
     cpu: [x64]
     os: [linux]
 
@@ -1801,8 +1861,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.21.2':
+    resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-win32-arm64-msvc@4.18.1':
     resolution: {integrity: sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.21.2':
+    resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -1811,35 +1881,45 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.21.2':
+    resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.21.2':
+    resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
     cpu: [x64]
     os: [win32]
 
   '@rushstack/eslint-patch@1.10.3':
     resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
 
-  '@rushstack/node-core-library@5.4.1':
-    resolution: {integrity: sha512-WNnwdS8r9NZ/2K3u29tNoSRldscFa7SxU0RT+82B6Dy2I4Hl2MeCSKm4EXLXPKeNzLGvJ1cqbUhTLviSF8E6iA==}
+  '@rushstack/node-core-library@5.5.1':
+    resolution: {integrity: sha512-ZutW56qIzH8xIOlfyaLQJFx+8IBqdbVCZdnj+XT1MorQ1JqqxHse8vbCpEM+2MjsrqcbxcgDIbfggB1ZSQ2A3g==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/rig-package@0.5.2':
-    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
-  '@rushstack/terminal@0.13.0':
-    resolution: {integrity: sha512-Ou44Q2s81BqJu3dpYedAX54am9vn245F0HzqVrfJCMQk5pGgoKKOBOjkbfZC9QKcGNaECh6pwH2s5noJt7X6ew==}
+  '@rushstack/terminal@0.13.3':
+    resolution: {integrity: sha512-fc3zjXOw8E0pXS5t9vTiIPx9gHA0fIdTXsu9mT4WbH+P3mYvnrX0iAQ5a6NvyK1+CqYWBTw/wVNx7SDJkI+WYQ==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/ts-command-line@4.22.0':
-    resolution: {integrity: sha512-Qj28t6MO3HRgAZ72FDeFsrpdE6wBWxF3VENgvrXh7JF2qIT+CrXiOJIesW80VFZB9QwObSpkB1ilx794fGQg6g==}
+  '@rushstack/ts-command-line@4.22.3':
+    resolution: {integrity: sha512-edMpWB3QhFFZ4KtSzS8WNjBgR4PXPPOVrOHMbb7kNpmQ1UFS9HdVtjCXg1H5fG+xYAbeE+TMPcVPUyX2p84STA==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -2364,29 +2444,32 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
 
-  '@vitest/expect@1.2.2':
-    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
+  '@vitest/expect@2.0.5':
+    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
-  '@vitest/runner@1.2.2':
-    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
+  '@vitest/pretty-format@2.0.5':
+    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
-  '@vitest/snapshot@1.2.2':
-    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
+  '@vitest/runner@2.0.5':
+    resolution: {integrity: sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==}
 
-  '@vitest/spy@1.2.2':
-    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
+  '@vitest/snapshot@2.0.5':
+    resolution: {integrity: sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==}
 
-  '@vitest/utils@1.2.2':
-    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
+  '@vitest/spy@2.0.5':
+    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
 
-  '@volar/language-core@1.11.1':
-    resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
+  '@vitest/utils@2.0.5':
+    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
-  '@volar/source-map@1.11.1':
-    resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
+  '@volar/language-core@2.4.1':
+    resolution: {integrity: sha512-9AKhC7Qn2mQYxj7Dz3bVxeOk7gGJladhWixUYKef/o0o7Bm4an+A3XvmcTHVqZ8stE6lBVH++g050tBtJ4TZPQ==}
 
-  '@volar/typescript@1.11.1':
-    resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
+  '@volar/source-map@2.4.1':
+    resolution: {integrity: sha512-Xq6ep3OZg9xUqN90jEgB9ztX5SsTz1yiV8wiQbcYNjWkek+Ie3dc8l7AVt3EhDm9mSIR58oWczHkzM2H6HIsmQ==}
+
+  '@volar/typescript@2.4.1':
+    resolution: {integrity: sha512-UoRzC0PXcwajFQTu8XxKSYNsWNBtVja6Y9gC8eLv7kYm+UEKJCcZ8g7dialsOYA0HKs3Vpg57MeCsawFLC6m9Q==}
 
   '@vue/compiler-core@3.4.31':
     resolution: {integrity: sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==}
@@ -2394,8 +2477,11 @@ packages:
   '@vue/compiler-dom@3.4.31':
     resolution: {integrity: sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==}
 
-  '@vue/language-core@1.8.27':
-    resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/language-core@2.0.29':
+    resolution: {integrity: sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2594,8 +2680,9 @@ packages:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -2761,9 +2848,9 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
-    engines: {node: '>=4'}
+  chai@5.1.1:
+    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2796,8 +2883,9 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2903,6 +2991,9 @@ packages:
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   computeds@0.0.1:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
@@ -3030,6 +3121,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.6:
+    resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
 
@@ -3044,8 +3144,8 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
-  deep-eql@4.1.4:
-    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-equal@1.0.1:
@@ -4373,8 +4473,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+  loupe@3.1.1:
+    resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -4395,6 +4495,9 @@ packages:
 
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+
+  magic-string@0.30.11:
+    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -4815,8 +4918,8 @@ packages:
       typescript:
         optional: true
 
-  muggle-string@0.3.1:
-    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -5029,10 +5132,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -5120,8 +5219,9 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -5212,6 +5312,10 @@ packages:
 
   postcss@8.4.39:
     resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.43:
+    resolution: {integrity: sha512-gJAQVYbh5R3gYm33FijzCZj7CHyQ3hWMgJMprLUlIYqCwTeZhBQ19wp0e9mA25BUbEvY5+EXuuaAjqQsrBxQBQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.2:
@@ -5493,6 +5597,11 @@ packages:
 
   rollup@4.18.1:
     resolution: {integrity: sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.21.2:
+    resolution: {integrity: sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5797,9 +5906,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@1.3.0:
-    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
-
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
 
@@ -5894,12 +6000,16 @@ packages:
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
 
-  tinypool@0.8.4:
-    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+  tinypool@1.0.1:
+    resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+  tinyspy@3.0.0:
+    resolution: {integrity: sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==}
     engines: {node: '>=14.0.0'}
 
   titleize@3.0.0:
@@ -6035,10 +6145,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
 
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -6230,18 +6336,18 @@ packages:
   vfile@6.0.1:
     resolution: {integrity: sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==}
 
-  vite-node@1.2.2:
-    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   vite-node@1.6.0:
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-plugin-dts@3.6.4:
-    resolution: {integrity: sha512-yOVhUI/kQhtS6lCXRYYLv2UUf9bftcwQK9ROxCX2ul17poLQs02ctWX7+vXB8GPRzH8VCK3jebEFtPqqijXx6w==}
+  vite-node@2.0.5:
+    resolution: {integrity: sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite-plugin-dts@4.1.0:
+    resolution: {integrity: sha512-sRlmt9k2q8MrX4F2058N3KmB6WyJ3Ao6QaExOv1X99F3j0GhPziEz1zscWQ1q2r1PeFc96L7GIUu8Pl2DPr2Hg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -6314,6 +6420,37 @@ packages:
       terser:
         optional: true
 
+  vite@5.4.2:
+    resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vitefu@0.2.5:
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
@@ -6327,15 +6464,15 @@ packages:
     peerDependencies:
       vitest: '*'
 
-  vitest@1.2.2:
-    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
+  vitest@2.0.5:
+    resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
+      '@vitest/browser': 2.0.5
+      '@vitest/ui': 2.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -6355,14 +6492,14 @@ packages:
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
-  vue-template-compiler@2.7.16:
-    resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
-  vue-tsc@1.8.27:
-    resolution: {integrity: sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==}
+  vue-tsc@2.0.29:
+    resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
     hasBin: true
     peerDependencies:
-      typescript: '*'
+      typescript: '>=5.0.0'
 
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -7676,23 +7813,23 @@ snapshots:
       '@types/react': 18.3.3
       react: 18.3.1
 
-  '@microsoft/api-extractor-model@7.29.2(@types/node@20.14.10)':
+  '@microsoft/api-extractor-model@7.29.4(@types/node@20.14.10)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.4.1(@types/node@20.14.10)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.14.10)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.0(@types/node@20.14.10)':
+  '@microsoft/api-extractor@7.47.4(@types/node@20.14.10)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.2(@types/node@20.14.10)
+      '@microsoft/api-extractor-model': 7.29.4(@types/node@20.14.10)
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.4.1(@types/node@20.14.10)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.13.0(@types/node@20.14.10)
-      '@rushstack/ts-command-line': 4.22.0(@types/node@20.14.10)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.14.10)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.13.3(@types/node@20.14.10)
+      '@rushstack/ts-command-line': 4.22.3(@types/node@20.14.10)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -7794,65 +7931,113 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.18.1)':
+  '@rollup/pluginutils@5.1.0(rollup@4.21.2)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.18.1
+      rollup: 4.21.2
 
   '@rollup/rollup-android-arm-eabi@4.18.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.21.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.18.1':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.21.2':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.18.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.21.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.18.1':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.21.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.21.2':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.21.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.18.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.18.1':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.21.2':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.18.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
+  '@rollup/rollup-win32-x64-msvc@4.21.2':
+    optional: true
+
   '@rushstack/eslint-patch@1.10.3': {}
 
-  '@rushstack/node-core-library@5.4.1(@types/node@20.14.10)':
+  '@rushstack/node-core-library@5.5.1(@types/node@20.14.10)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -7865,21 +8050,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.10
 
-  '@rushstack/rig-package@0.5.2':
+  '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.13.0(@types/node@20.14.10)':
+  '@rushstack/terminal@0.13.3(@types/node@20.14.10)':
     dependencies:
-      '@rushstack/node-core-library': 5.4.1(@types/node@20.14.10)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.14.10)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.14.10
 
-  '@rushstack/ts-command-line@4.22.0(@types/node@20.14.10)':
+  '@rushstack/ts-command-line@4.22.3(@types/node@20.14.10)':
     dependencies:
-      '@rushstack/terminal': 0.13.0(@types/node@20.14.10)
+      '@rushstack/terminal': 0.13.3(@types/node@20.14.10)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -8011,7 +8196,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.6(@types/jest@29.5.12)(vitest@1.2.2(@types/node@20.14.10)(jsdom@22.1.0))':
+  '@testing-library/jest-dom@6.4.6(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.14.10)(jsdom@22.1.0))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.8
@@ -8023,7 +8208,7 @@ snapshots:
       redent: 3.0.0
     optionalDependencies:
       '@types/jest': 29.5.12
-      vitest: 1.2.2(@types/node@20.14.10)(jsdom@22.1.0)
+      vitest: 2.0.5(@types/node@20.14.10)(jsdom@22.1.0)
 
   '@testing-library/react@14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -8470,13 +8655,14 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.1
       outdent: 0.8.0
-      vite: 5.0.12(@types/node@20.14.10)
+      vite: 5.4.2(@types/node@20.14.10)
       vite-node: 1.6.0(@types/node@20.14.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -8488,18 +8674,19 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.14.2
 
-  '@vanilla-extract/vite-plugin@3.9.5(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2))(vite@5.0.12(@types/node@20.14.10))':
+  '@vanilla-extract/vite-plugin@3.9.5(@types/node@20.14.10)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2))(vite@5.4.2(@types/node@20.14.10))':
     dependencies:
       '@vanilla-extract/integration': 6.5.0(@types/node@20.14.10)
       outdent: 0.8.0
       postcss: 8.4.27
       postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.10)(typescript@5.4.2))
-      vite: 5.0.12(@types/node@20.14.10)
+      vite: 5.4.2(@types/node@20.14.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -8518,6 +8705,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -8536,6 +8724,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -8609,47 +8798,61 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@1.2.2':
+  '@vitejs/plugin-react@4.3.1(vite@5.4.2(@types/node@20.14.10))':
     dependencies:
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
-      chai: 4.4.1
+      '@babel/core': 7.24.8
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.8)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.8)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.4.2(@types/node@20.14.10)
+    transitivePeerDependencies:
+      - supports-color
 
-  '@vitest/runner@1.2.2':
+  '@vitest/expect@2.0.5':
     dependencies:
-      '@vitest/utils': 1.2.2
-      p-limit: 5.0.0
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@2.0.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.0.5':
+    dependencies:
+      '@vitest/utils': 2.0.5
       pathe: 1.1.2
 
-  '@vitest/snapshot@1.2.2':
+  '@vitest/snapshot@2.0.5':
     dependencies:
+      '@vitest/pretty-format': 2.0.5
       magic-string: 0.30.10
       pathe: 1.1.2
-      pretty-format: 29.7.0
 
-  '@vitest/spy@1.2.2':
+  '@vitest/spy@2.0.5':
     dependencies:
-      tinyspy: 2.2.1
+      tinyspy: 3.0.0
 
-  '@vitest/utils@1.2.2':
+  '@vitest/utils@2.0.5':
     dependencies:
-      diff-sequences: 29.6.3
+      '@vitest/pretty-format': 2.0.5
       estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      loupe: 3.1.1
+      tinyrainbow: 1.2.0
 
-  '@volar/language-core@1.11.1':
+  '@volar/language-core@2.4.1':
     dependencies:
-      '@volar/source-map': 1.11.1
+      '@volar/source-map': 2.4.1
 
-  '@volar/source-map@1.11.1':
-    dependencies:
-      muggle-string: 0.3.1
+  '@volar/source-map@2.4.1': {}
 
-  '@volar/typescript@1.11.1':
+  '@volar/typescript@2.4.1':
     dependencies:
-      '@volar/language-core': 1.11.1
+      '@volar/language-core': 2.4.1
       path-browserify: 1.0.1
+      vscode-uri: 3.0.8
 
   '@vue/compiler-core@3.4.31':
     dependencies:
@@ -8664,17 +8867,21 @@ snapshots:
       '@vue/compiler-core': 3.4.31
       '@vue/shared': 3.4.31
 
-  '@vue/language-core@1.8.27(typescript@5.4.2)':
+  '@vue/compiler-vue2@2.7.16':
     dependencies:
-      '@volar/language-core': 1.11.1
-      '@volar/source-map': 1.11.1
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/language-core@2.0.29(typescript@5.4.2)':
+    dependencies:
+      '@volar/language-core': 2.4.1
       '@vue/compiler-dom': 3.4.31
+      '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.4.31
       computeds: 0.0.1
       minimatch: 9.0.5
-      muggle-string: 0.3.1
+      muggle-string: 0.4.1
       path-browserify: 1.0.1
-      vue-template-compiler: 2.7.16
     optionalDependencies:
       typescript: 5.4.2
 
@@ -8894,7 +9101,7 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
-  assertion-error@1.1.0: {}
+  assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -9147,15 +9354,13 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@4.4.1:
+  chai@5.1.1:
     dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.0.8
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.1
+      pathval: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -9185,9 +9390,7 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -9278,6 +9481,8 @@ snapshots:
   commander@4.1.1: {}
 
   common-ancestor-path@1.0.1: {}
+
+  compare-versions@6.1.1: {}
 
   computeds@0.0.1: {}
 
@@ -9392,6 +9597,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.3.6:
+    dependencies:
+      ms: 2.1.2
+
   decimal.js@10.4.3: {}
 
   decode-named-character-reference@1.0.2:
@@ -9405,9 +9614,7 @@ snapshots:
       mimic-response: 3.1.0
     optional: true
 
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.0.8
+  deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
 
@@ -11198,7 +11405,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
+  loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
 
@@ -11220,6 +11427,10 @@ snapshots:
   lz-string@1.5.0: {}
 
   magic-string@0.30.10:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -12079,7 +12290,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.2
 
-  muggle-string@0.3.1: {}
+  muggle-string@0.4.1: {}
 
   mute-stream@1.0.0: {}
 
@@ -12335,10 +12546,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.1.1
 
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.1.1
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -12414,7 +12621,7 @@ snapshots:
 
   pathe@1.1.2: {}
 
-  pathval@1.1.1: {}
+  pathval@2.0.0: {}
 
   periscopic@3.1.0:
     dependencies:
@@ -12525,6 +12732,12 @@ snapshots:
       source-map-js: 1.2.0
 
   postcss@8.4.39:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+
+  postcss@8.4.43:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
@@ -12936,6 +13149,28 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.18.1
       fsevents: 2.3.3
 
+  rollup@4.21.2:
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.21.2
+      '@rollup/rollup-android-arm64': 4.21.2
+      '@rollup/rollup-darwin-arm64': 4.21.2
+      '@rollup/rollup-darwin-x64': 4.21.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.21.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.21.2
+      '@rollup/rollup-linux-arm64-gnu': 4.21.2
+      '@rollup/rollup-linux-arm64-musl': 4.21.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.21.2
+      '@rollup/rollup-linux-s390x-gnu': 4.21.2
+      '@rollup/rollup-linux-x64-gnu': 4.21.2
+      '@rollup/rollup-linux-x64-musl': 4.21.2
+      '@rollup/rollup-win32-arm64-msvc': 4.21.2
+      '@rollup/rollup-win32-ia32-msvc': 4.21.2
+      '@rollup/rollup-win32-x64-msvc': 4.21.2
+      fsevents: 2.3.3
+
   rrweb-cssom@0.6.0: {}
 
   run-applescript@5.0.0:
@@ -13276,10 +13511,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@1.3.0:
-    dependencies:
-      acorn: 8.12.1
-
   style-to-object@0.4.4:
     dependencies:
       inline-style-parser: 0.1.1
@@ -13444,9 +13675,11 @@ snapshots:
 
   tinybench@2.8.0: {}
 
-  tinypool@0.8.4: {}
+  tinypool@1.0.1: {}
 
-  tinyspy@2.2.1: {}
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.0: {}
 
   titleize@3.0.0: {}
 
@@ -13611,8 +13844,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.0.8: {}
 
   type-fest@0.20.2: {}
 
@@ -13843,51 +14074,57 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.2.2(@types/node@20.14.10):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.5
-      pathe: 1.1.2
-      picocolors: 1.0.1
-      vite: 5.0.12(@types/node@20.14.10)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@1.6.0(@types/node@20.14.10):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.0.12(@types/node@20.14.10)
+      vite: 5.4.2(@types/node@20.14.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
       - terser
 
-  vite-plugin-dts@3.6.4(@types/node@20.14.10)(rollup@4.18.1)(typescript@5.4.2)(vite@5.0.12(@types/node@20.14.10)):
+  vite-node@2.0.5(@types/node@20.14.10):
     dependencies:
-      '@microsoft/api-extractor': 7.47.0(@types/node@20.14.10)
-      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
-      '@vue/language-core': 1.8.27(typescript@5.4.2)
+      cac: 6.7.14
       debug: 4.3.5
+      pathe: 1.1.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.2(@types/node@20.14.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-plugin-dts@4.1.0(@types/node@20.14.10)(rollup@4.21.2)(typescript@5.4.2)(vite@5.4.2(@types/node@20.14.10)):
+    dependencies:
+      '@microsoft/api-extractor': 7.47.4(@types/node@20.14.10)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@volar/typescript': 2.4.1
+      '@vue/language-core': 2.0.29(typescript@5.4.2)
+      compare-versions: 6.1.1
+      debug: 4.3.6
       kolorist: 1.8.0
+      local-pkg: 0.5.0
+      magic-string: 0.30.11
       typescript: 5.4.2
-      vue-tsc: 1.8.27(typescript@5.4.2)
+      vue-tsc: 2.0.29(typescript@5.4.2)
     optionalDependencies:
-      vite: 5.0.12(@types/node@20.14.10)
+      vite: 5.4.2(@types/node@20.14.10)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -13922,37 +14159,44 @@ snapshots:
       '@types/node': 20.14.10
       fsevents: 2.3.3
 
+  vite@5.4.2(@types/node@20.14.10):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.43
+      rollup: 4.21.2
+    optionalDependencies:
+      '@types/node': 20.14.10
+      fsevents: 2.3.3
+
   vitefu@0.2.5(vite@4.5.3(@types/node@20.14.10)):
     optionalDependencies:
       vite: 4.5.3(@types/node@20.14.10)
 
-  vitest-canvas-mock@0.3.3(vitest@1.2.2(@types/node@20.14.10)(jsdom@22.1.0)):
+  vitest-canvas-mock@0.3.3(vitest@2.0.5(@types/node@20.14.10)(jsdom@22.1.0)):
     dependencies:
       jest-canvas-mock: 2.5.2
-      vitest: 1.2.2(@types/node@20.14.10)(jsdom@22.1.0)
+      vitest: 2.0.5(@types/node@20.14.10)(jsdom@22.1.0)
 
-  vitest@1.2.2(@types/node@20.14.10)(jsdom@22.1.0):
+  vitest@2.0.5(@types/node@20.14.10)(jsdom@22.1.0):
     dependencies:
-      '@vitest/expect': 1.2.2
-      '@vitest/runner': 1.2.2
-      '@vitest/snapshot': 1.2.2
-      '@vitest/spy': 1.2.2
-      '@vitest/utils': 1.2.2
-      acorn-walk: 8.3.3
-      cac: 6.7.14
-      chai: 4.4.1
+      '@ampproject/remapping': 2.3.0
+      '@vitest/expect': 2.0.5
+      '@vitest/pretty-format': 2.0.5
+      '@vitest/runner': 2.0.5
+      '@vitest/snapshot': 2.0.5
+      '@vitest/spy': 2.0.5
+      '@vitest/utils': 2.0.5
+      chai: 5.1.1
       debug: 4.3.5
       execa: 8.0.1
-      local-pkg: 0.5.0
       magic-string: 0.30.10
       pathe: 1.1.2
-      picocolors: 1.0.1
       std-env: 3.7.0
-      strip-literal: 1.3.0
       tinybench: 2.8.0
-      tinypool: 0.8.4
-      vite: 5.0.12(@types/node@20.14.10)
-      vite-node: 1.2.2(@types/node@20.14.10)
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.2(@types/node@20.14.10)
+      vite-node: 2.0.5(@types/node@20.14.10)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.10
@@ -13961,6 +14205,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -13968,15 +14213,12 @@ snapshots:
 
   vscode-languageserver-types@3.17.5: {}
 
-  vue-template-compiler@2.7.16:
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
+  vscode-uri@3.0.8: {}
 
-  vue-tsc@1.8.27(typescript@5.4.2):
+  vue-tsc@2.0.29(typescript@5.4.2):
     dependencies:
-      '@volar/typescript': 1.11.1
-      '@vue/language-core': 1.8.27(typescript@5.4.2)
+      '@volar/typescript': 2.4.1
+      '@vue/language-core': 2.0.29(typescript@5.4.2)
       semver: 7.6.2
       typescript: 5.4.2
 


### PR DESCRIPTION
# Description

This pull request aim to figure out the best way to allow users to supply monaco editor from their project instead of being bundled with Pathfinder.
The goal is to not have 2 monaco-editor chunks in the final build.

# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [x] 🛠️ Tooling
- [ ] 🔨 Refactoring
- [ ] 🧪 Test
- [x] 📦 Dependency
- [ ] 📖 Requires documentation update
