### PR TITLE
conditionally load workers based on package mode

### DIFF
--- a/.changeset/nasty-boats-complain.md
+++ b/.changeset/nasty-boats-complain.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Removes worker loading from "lite" mode. Please ensure that your consuming applications are properly implementing and loading the following Monaco workers: editor, json, monaco-graphql.

--- a/packages/react/src/components/editor/workers.ts
+++ b/packages/react/src/components/editor/workers.ts
@@ -2,20 +2,22 @@ import JsonWorker from '../../../workers/json.worker.bundle?worker';
 import EditorWorker from '../../../workers/editor.worker.bundle?worker';
 import GraphQLWorker from '../../../workers/graphql.worker.bundle?worker';
 
-self.MonacoEnvironment = {
-  getWorker(_workerId: string, label: string): Worker {
-    switch (label) {
-      case 'json': {
-        return new JsonWorker();
-      }
+if (import.meta.__IS_LITE_MODE_ !== 'true') {
+  self.MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      switch (label) {
+        case 'json': {
+          return new JsonWorker();
+        }
 
-      case 'graphql': {
-        return new GraphQLWorker();
-      }
+        case 'graphql': {
+          return new GraphQLWorker();
+        }
 
-      default: {
-        return new EditorWorker();
+        default: {
+          return new EditorWorker();
+        }
       }
-    }
-  },
-};
+    },
+  };
+}


### PR DESCRIPTION
This PR adds to the recent `lite` mode updates by loading workers only for our "full" mode.
