### PR TITLE
Improvements to enable pathfinder to handle large schemas.

### DIFF
--- a/examples/nextjs-example/package.json
+++ b/examples/nextjs-example/package.json
@@ -16,6 +16,7 @@
     "autoprefixer": "10.4.14",
     "eslint": "8.56.0",
     "eslint-config-next": "13.4.12",
+    "graphql": "^16.9.0",
     "next": "13.5.3",
     "next-global-css": "1.3.1",
     "postcss": "8.4.27",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.19",
+    "@tanstack/react-virtual": "^3.10.8",
     "idb-keyval": "6.2.1",
     "lodash": "^4.17.21",
     "monaco-editor": "0.40.0",
@@ -69,8 +70,8 @@
     "vitest-canvas-mock": "0.3.3"
   },
   "peerDependencies": {
+    "graphql": "16.9.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "graphql": "16.9.0"
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@headlessui/react": "1.7.19",
     "@tanstack/react-virtual": "^3.10.8",
+    "fuzzysort": "^3.0.2",
     "idb-keyval": "6.2.1",
     "lodash": "^4.17.21",
     "monaco-editor": "0.40.0",

--- a/packages/react/src/compass/components/field/field.tsx
+++ b/packages/react/src/compass/components/field/field.tsx
@@ -27,19 +27,21 @@ export const Field = ({ ancestors }: { ancestors: AncestorsArray }) => {
     return [];
   };
 
-  let childFieldsToRender: React.ReactNode = null;
+  let renderChildFields: undefined | (() => React.ReactNode) = undefined;
 
   if (isObjectType(unwrappedType) || isInterfaceType(unwrappedType)) {
     const fields = unwrappedType.getFields();
-    childFieldsToRender = fields && (
-      <Fields
-        ancestors={ancestors}
-        fields={unwrappedType.getFields()}
-        parentSelections={parentSelections()}
-      />
-    );
+    renderChildFields =
+      fields &&
+      (() => (
+        <Fields
+          ancestors={ancestors}
+          fields={unwrappedType.getFields()}
+          parentSelections={parentSelections()}
+        />
+      ));
   } else if (isUnionType(unwrappedType)) {
-    childFieldsToRender = (
+    renderChildFields = () => (
       <Union
         ancestors={ancestors}
         parentSelections={parentSelections()}
@@ -57,7 +59,7 @@ export const Field = ({ ancestors }: { ancestors: AncestorsArray }) => {
               arguments: field.args.length > 0 && (
                 <Arguments ancestors={ancestors} selection={selection as FieldNode} />
               ),
-              childFields: childFieldsToRender,
+              renderChildFields,
             }
           : undefined
       }

--- a/packages/react/src/compass/components/list-item/list-item.tsx
+++ b/packages/react/src/compass/components/list-item/list-item.tsx
@@ -71,9 +71,9 @@ export const ListItem = ({
               )}
 
               {collapsibleContent.arguments && collapsibleContent.arguments}
-              {isExpanded && collapsibleContent.childFields && (
+              {isExpanded && collapsibleContent.renderChildFields && (
                 <ul className={listItemChildFieldsClass}>
-                  {collapsibleContent.childFields}
+                  {collapsibleContent.renderChildFields()}
                 </ul>
               )}
             </>

--- a/packages/react/src/compass/components/list-item/list-item.types.ts
+++ b/packages/react/src/compass/components/list-item/list-item.types.ts
@@ -23,7 +23,7 @@ type ListItemBaseProps = {
 type ListItemWithCollapserProps = {
   collapsibleContent?: {
     arguments?: React.ReactNode;
-    childFields?: React.ReactNode;
+    renderChildFields?: () => React.ReactNode;
   };
 };
 

--- a/packages/react/src/compass/components/root-operation/root-operation.css.ts
+++ b/packages/react/src/compass/components/root-operation/root-operation.css.ts
@@ -1,13 +1,51 @@
 import { contract, shared, style } from '@pathfinder-ide/style';
 
-export const rootOperationClass = style([
-  shared.scrollbars,
-  {
-    height: '100%',
+export const rootOperationStyles = {
+  container: style({
     width: '100%',
-    overflowY: 'auto',
-    contain: 'strict',
-    padding: contract.space[16],
-    margin: 0,
-  },
-]);
+    height: '100%',
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: contract.space[16],
+  }),
+
+  searchContainer: style({
+    paddingInline: contract.space[16],
+    paddingBlockStart: contract.space[16],
+  }),
+
+  searchInputWrapper: style({
+    paddingBlock: contract.space[4],
+    color: contract.color.neutral[11],
+    fontSize: 14,
+    display: 'flex',
+    gap: contract.space[8],
+    alignItems: 'center',
+    borderBottom: `1px solid ${contract.color.neutral[9]}`,
+
+    selectors: {
+      '&:focus-within': {
+        borderBottomColor: contract.color.neutral[12],
+        color: contract.color.neutral[12],
+      },
+    },
+  }),
+
+  searchInput: style({
+    background: 'transparent',
+    width: '100%',
+    outline: 'none',
+  }),
+
+  operationsListContainer: style([
+    shared.scrollbars,
+    {
+      flex: 1,
+      overflowY: 'auto',
+      contain: 'strict',
+      paddingBlockEnd: contract.space[16],
+      paddingInlineStart: contract.space[16],
+    },
+  ]),
+};

--- a/packages/react/src/compass/components/root-operation/root-operation.css.ts
+++ b/packages/react/src/compass/components/root-operation/root-operation.css.ts
@@ -5,10 +5,9 @@ export const rootOperationClass = style([
   {
     height: '100%',
     width: '100%',
+    overflowY: 'auto',
+    contain: 'strict',
     padding: contract.space[16],
     margin: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
   },
 ]);

--- a/packages/react/src/compass/components/root-operation/root-operation.css.ts
+++ b/packages/react/src/compass/components/root-operation/root-operation.css.ts
@@ -8,6 +8,7 @@ export const rootOperationStyles = {
     display: 'flex',
     flexDirection: 'column',
     gap: contract.space[16],
+    paddingBlock: contract.space[16],
   }),
 
   searchContainer: style({

--- a/packages/react/src/compass/components/root-operation/root-operation.tsx
+++ b/packages/react/src/compass/components/root-operation/root-operation.tsx
@@ -69,7 +69,7 @@ export const RootOperation = ({
 
   return (
     <div className={rootOperationStyles.container}>
-      <div className={rootOperationStyles.searchContainer}>
+      {/* <div className={rootOperationStyles.searchContainer}>
         <div className={rootOperationStyles.searchInputWrapper}>
           <Icon name="MagnifingGlass" size="small" />
           <input
@@ -81,7 +81,7 @@ export const RootOperation = ({
             className={rootOperationStyles.searchInput}
           />
         </div>
-      </div>
+      </div> */}
       <div ref={parentRef} className={rootOperationStyles.operationsListContainer}>
         <div
           style={{

--- a/packages/react/src/compass/components/root-operation/root-operation.tsx
+++ b/packages/react/src/compass/components/root-operation/root-operation.tsx
@@ -7,7 +7,6 @@ import { Field } from '../field';
 import { rootOperationStyles } from './root-operation.css';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useMemo, useRef, useState } from 'react';
-import { Icon } from '../../../components';
 import fuzzysort from 'fuzzysort';
 
 export const RootOperation = ({
@@ -20,7 +19,7 @@ export const RootOperation = ({
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue] = useState('');
 
   const allFields = useMemo(() => {
     return Object.keys(fields ?? {})

--- a/packages/react/src/compass/components/root-operation/root-operation.tsx
+++ b/packages/react/src/compass/components/root-operation/root-operation.tsx
@@ -5,6 +5,8 @@ import type { AncestorRoot, AncestorsArray } from '../../compass-store';
 import { Field } from '../field';
 
 import { rootOperationClass } from './root-operation.css';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useRef } from 'react';
 
 export const RootOperation = ({
   ancestors,
@@ -14,9 +16,19 @@ export const RootOperation = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fields: GraphQLFieldMap<any, any> | undefined;
 }) => {
+  const parentRef = useRef<HTMLDivElement>(null);
   const { operationDefinition, operationType } = ancestors[
     ancestors.length - 1
   ] as AncestorRoot;
+
+  const fieldsSorted = Object.keys(fields ?? {}).sort();
+
+  const count = fieldsSorted.length;
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 22,
+  });
 
   if (!fields) {
     return (
@@ -27,26 +39,54 @@ export const RootOperation = ({
     );
   }
 
+  const items = virtualizer.getVirtualItems();
+
   return (
-    <ul className={rootOperationClass}>
-      {Object.keys(fields)
-        .sort()
-        .map((field) => (
-          <Field
-            key={field}
-            ancestors={[
-              ...ancestors,
-              {
-                type: 'FIELD',
-                field: fields[field],
-                selection:
-                  operationDefinition?.selectionSet?.selections.find((s) =>
-                    'name' in s ? s.name.value === fields[field].name : false,
-                  ) || null,
-              },
-            ]}
-          />
-        ))}
-    </ul>
+    <div ref={parentRef} className={rootOperationClass}>
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${items[0]?.start ?? 0}px)`,
+          }}
+        >
+          {items.map((virtualRow) => {
+            const fieldKey = fieldsSorted[virtualRow.index];
+
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+              >
+                <Field
+                  key={virtualRow.key}
+                  ancestors={[
+                    ...ancestors,
+                    {
+                      type: 'FIELD',
+                      field: fields[fieldKey],
+                      selection:
+                        operationDefinition?.selectionSet?.selections.find((s) =>
+                          'name' in s ? s.name.value === fields[fieldKey].name : false,
+                        ) || null,
+                    },
+                  ]}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
   );
 };

--- a/packages/react/src/compass/components/union/union.tsx
+++ b/packages/react/src/compass/components/union/union.tsx
@@ -62,7 +62,7 @@ const UnionMember = ({
     <ListItem
       ancestors={newAncestors}
       collapsibleContent={{
-        childFields: (
+        renderChildFields: () => (
           <Fields
             ancestors={newAncestors}
             fields={objectMember.getFields()}

--- a/packages/react/src/components/icon/icon.types.ts
+++ b/packages/react/src/components/icon/icon.types.ts
@@ -11,6 +11,7 @@ import { Gear } from './gear';
 import { GraphQL } from './graphql';
 import { InsertNewOperation } from './insert-new-operation';
 import { Interpunct } from './interpunct';
+import { MagnifingGlass } from './magnifing-glass';
 import { Pause } from './pause';
 import { Plus } from './plus';
 import { Prettier } from './prettier';
@@ -29,6 +30,7 @@ export const IconMap = {
   GraphQL,
   InsertNewOperation,
   Interpunct,
+  MagnifingGlass,
   Pause,
   Plus,
   Prettier,

--- a/packages/react/src/components/icon/magnifing-glass/index.ts
+++ b/packages/react/src/components/icon/magnifing-glass/index.ts
@@ -1,0 +1,1 @@
+export { MagnifingGlass } from './magnifing-glass';

--- a/packages/react/src/components/icon/magnifing-glass/magnifing-glass.tsx
+++ b/packages/react/src/components/icon/magnifing-glass/magnifing-glass.tsx
@@ -1,0 +1,9 @@
+export const MagnifingGlass = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+      <path d="M22 20L20 22 14 16 14 14 16 14z"></path>
+      <path d="M9,16c-3.9,0-7-3.1-7-7c0-3.9,3.1-7,7-7c3.9,0,7,3.1,7,7C16,12.9,12.9,16,9,16z M9,4C6.2,4,4,6.2,4,9c0,2.8,2.2,5,5,5 c2.8,0,5-2.2,5-5C14,6.2,11.8,4,9,4z"></path>
+      <path d="M13.7 12.5H14.7V16H13.7z" transform="rotate(-44.992 14.25 14.25)"></path>
+    </svg>
+  );
+};

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -44,29 +44,23 @@ export const Tabs = ({
               onSurface: styles.onSurface,
             })}`}
           >
-            {tabs.map((tab) => {
-              const ButtonContent = tab.buttonContent;
-              return (
-                <Tab
-                  className={tabButtonClass}
-                  key={tab.name}
-                  onClick={() => (tab.action ? tab.action() : undefined)}
-                >
-                  <ButtonContent />
-                </Tab>
-              );
-            })}
+            {tabs.map((tab) => (
+              <Tab
+                className={tabButtonClass}
+                key={tab.name}
+                onClick={() => (tab.action ? tab.action() : undefined)}
+              >
+                {tab.buttonContent()}
+              </Tab>
+            ))}
           </div>
         </Tab.List>
         <Tab.Panels className={tabPanelsClass}>
-          {tabs.map((tab) => {
-            const PanelContent = tab.panelContent;
-            return (
-              <Tab.Panel className={tabPanelClass} key={tab.name} unmount={false}>
-                <PanelContent />
-              </Tab.Panel>
-            );
-          })}
+          {tabs.map((tab) => (
+            <Tab.Panel className={tabPanelClass} key={tab.name} unmount={false}>
+              {tab.panelContent()}
+            </Tab.Panel>
+          ))}
         </Tab.Panels>
       </div>
     </Tab.Group>

--- a/packages/react/src/components/tabs/tabs.types.ts
+++ b/packages/react/src/components/tabs/tabs.types.ts
@@ -1,8 +1,10 @@
+import { ReactNode } from 'react';
+
 export type TabItem = {
   action?: () => void;
-  buttonContent: React.ElementType;
+  buttonContent: () => ReactNode;
   name: string;
-  panelContent: React.ElementType;
+  panelContent: () => ReactNode;
 };
 
 export type TabsProps = TabItem[];

--- a/packages/react/src/reference/reference.tsx
+++ b/packages/react/src/reference/reference.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { printSchema } from 'graphql';
 
 import { useSchemaStore, useThemeStore } from '@pathfinder-ide/stores';
@@ -81,6 +81,11 @@ export const Reference = ({
 
   const schema = useSchemaStore.use.schema();
 
+  const schemaString = useMemo(
+    () => (schema ? printSchema(schema) : undefined),
+    [schema],
+  );
+
   const [visiblePane, setVisiblePane] = useState<AvailablePanes>('pathfinder');
 
   if (!activeTheme) {
@@ -145,7 +150,7 @@ export const Reference = ({
           >
             <div className={schemaViewWrapOuterClass}>
               <div className={schemaViewWrapInnerClass}>
-                {schema ? <SchemaView schemaString={printSchema(schema)} /> : <></>}
+                {schema ? <SchemaView schemaString={schemaString} /> : <></>}
               </div>
             </div>
           </div>

--- a/packages/react/src/schema-documentation/components/leaf/index.tsx
+++ b/packages/react/src/schema-documentation/components/leaf/index.tsx
@@ -103,48 +103,27 @@ export const LeafInputObject = ({ type }: { type: GraphQLInputObjectType }) => {
   );
 };
 
-export const LeafInterface = ({
-  int,
-  getScrollElement,
-}: {
-  int: GraphQLInterfaceType;
-  getScrollElement: () => HTMLElement | null;
-}) => {
+export const LeafInterface = ({ int }: { int: GraphQLInterfaceType }) => {
   const fields = int.getFields();
   const interfaces = int.getInterfaces();
 
   return (
     <>
       <SectionDescription description={int.description} />
-      <SectionFields
-        fields={fields}
-        resetTertiaryPaneOnClick={false}
-        getScrollElement={getScrollElement}
-      />
+      <SectionFields fields={fields} resetTertiaryPaneOnClick={false} />
       <SectionInterface interfaces={interfaces} />
     </>
   );
 };
 
-export const LeafObject = ({
-  type,
-  getScrollElement,
-}: {
-  type: GraphQLObjectType;
-  getScrollElement: () => HTMLElement | null;
-}) => {
+export const LeafObject = ({ type }: { type: GraphQLObjectType }) => {
   const fields = type.getFields();
   const interfaces = type.getInterfaces();
 
   return (
     <>
       <SectionDescription description={type.description} />
-      <SectionFields
-        fields={fields}
-        parentType={type}
-        resetTertiaryPaneOnClick={false}
-        getScrollElement={getScrollElement}
-      />
+      <SectionFields fields={fields} parentType={type} resetTertiaryPaneOnClick={false} />
       <SectionInterface interfaces={interfaces} />
     </>
   );

--- a/packages/react/src/schema-documentation/components/leaf/index.tsx
+++ b/packages/react/src/schema-documentation/components/leaf/index.tsx
@@ -103,27 +103,48 @@ export const LeafInputObject = ({ type }: { type: GraphQLInputObjectType }) => {
   );
 };
 
-export const LeafInterface = ({ int }: { int: GraphQLInterfaceType }) => {
+export const LeafInterface = ({
+  int,
+  getScrollElement,
+}: {
+  int: GraphQLInterfaceType;
+  getScrollElement: () => HTMLElement | null;
+}) => {
   const fields = int.getFields();
   const interfaces = int.getInterfaces();
 
   return (
     <>
       <SectionDescription description={int.description} />
-      <SectionFields fields={fields} resetTertiaryPaneOnClick={false} />
+      <SectionFields
+        fields={fields}
+        resetTertiaryPaneOnClick={false}
+        getScrollElement={getScrollElement}
+      />
       <SectionInterface interfaces={interfaces} />
     </>
   );
 };
 
-export const LeafObject = ({ type }: { type: GraphQLObjectType }) => {
+export const LeafObject = ({
+  type,
+  getScrollElement,
+}: {
+  type: GraphQLObjectType;
+  getScrollElement: () => HTMLElement | null;
+}) => {
   const fields = type.getFields();
   const interfaces = type.getInterfaces();
 
   return (
     <>
       <SectionDescription description={type.description} />
-      <SectionFields fields={fields} parentType={type} resetTertiaryPaneOnClick={false} />
+      <SectionFields
+        fields={fields}
+        parentType={type}
+        resetTertiaryPaneOnClick={false}
+        getScrollElement={getScrollElement}
+      />
       <SectionInterface interfaces={interfaces} />
     </>
   );

--- a/packages/react/src/schema-documentation/components/leaf/index.tsx
+++ b/packages/react/src/schema-documentation/components/leaf/index.tsx
@@ -110,7 +110,7 @@ export const LeafInterface = ({ int }: { int: GraphQLInterfaceType }) => {
   return (
     <>
       <SectionDescription description={int.description} />
-      <SectionFields fields={fields} resetTertiaryPaneOnClick={false} />
+      <SectionFields fields={fields} resetTertiaryPaneOnClick={false} hideSearch />
       <SectionInterface interfaces={interfaces} />
     </>
   );
@@ -123,7 +123,12 @@ export const LeafObject = ({ type }: { type: GraphQLObjectType }) => {
   return (
     <>
       <SectionDescription description={type.description} />
-      <SectionFields fields={fields} parentType={type} resetTertiaryPaneOnClick={false} />
+      <SectionFields
+        fields={fields}
+        parentType={type}
+        resetTertiaryPaneOnClick={false}
+        hideSearch
+      />
       <SectionInterface interfaces={interfaces} />
     </>
   );

--- a/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
+++ b/packages/react/src/schema-documentation/components/schema-documentation/schema-documentation.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useMemo } from 'react';
 import { GraphQLSchema } from 'graphql';
 
 import { useSchemaDocumentationStore } from '../../store';
@@ -44,12 +44,17 @@ export const SchemaDocumentation = ({
     initializeTheme({ options: themeOptions });
   }, [themeOptions]);
 
+  const typeMap = schema?.getTypeMap();
+  const sortedTypesNullable = useMemo(() => {
+    if (!typeMap) return;
+    return sortTypes({ typeMap });
+  }, [typeMap]);
+
   if (!schema) {
     return <LoadingSchema />;
   }
 
-  const typeMap = schema.getTypeMap();
-  const sortedTypes = sortTypes({ typeMap });
+  const sortedTypes = sortedTypesNullable as ReturnType<typeof sortTypes>;
   const queryRootType = schema?.getQueryType();
   const mutationRootType = schema?.getMutationType();
   const subscriptionRootType = schema?.getSubscriptionType();

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.css.ts
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.css.ts
@@ -1,4 +1,4 @@
-import { recipe, shared } from '@pathfinder-ide/style';
+import { contract, recipe, shared, style } from '@pathfinder-ide/style';
 import { sharedPaneClass } from '../../shared.styles.css';
 
 export const secondaryPaneClass = recipe({
@@ -19,3 +19,45 @@ export const secondaryPaneClass = recipe({
     },
   },
 });
+
+export const secondaryPaneListClasses = {
+  container: style({
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+
+  searchContainer: style({}),
+
+  searchInputWrapper: style({
+    paddingBlock: contract.space[4],
+    color: contract.color.neutral[11],
+    fontSize: 14,
+    display: 'flex',
+    gap: contract.space[8],
+    alignItems: 'center',
+    borderBottom: `1px solid ${contract.color.neutral[9]}`,
+
+    selectors: {
+      '&:focus-within': {
+        borderBottomColor: contract.color.neutral[12],
+        color: contract.color.neutral[12],
+      },
+    },
+  }),
+
+  searchInput: style({
+    background: 'transparent',
+    width: '100%',
+    outline: 'none',
+  }),
+
+  fieldsListContainer: style([
+    shared.scrollbars,
+    {
+      flex: 1,
+      overflowY: 'auto',
+      contain: 'strict',
+    },
+  ]),
+};

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.css.ts
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.css.ts
@@ -2,7 +2,14 @@ import { recipe, shared } from '@pathfinder-ide/style';
 import { sharedPaneClass } from '../../shared.styles.css';
 
 export const secondaryPaneClass = recipe({
-  base: [shared.scrollbars, sharedPaneClass],
+  base: [
+    shared.scrollbars,
+    sharedPaneClass,
+    {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+  ],
 
   variants: {
     activeTertiaryPane: {

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -86,10 +86,8 @@ const List = ({
 
 const RootOperationDetails = ({
   rootOperationType,
-  getScrollElement,
 }: {
   rootOperationType: GraphQLObjectType;
-  getScrollElement: () => HTMLElement | null;
 }) => {
   const fields = rootOperationType.getFields();
 
@@ -103,7 +101,6 @@ const RootOperationDetails = ({
         fields={fields}
         parentType={rootOperationType}
         resetTertiaryPaneOnClick={true}
-        getScrollElement={getScrollElement}
       />
     </>
   );
@@ -130,30 +127,15 @@ export const SecondaryPane = ({
   let toRender: ReactElement = <></>;
 
   if (activePrimaryPane === 'Query' && queryRootType) {
-    toRender = (
-      <RootOperationDetails
-        rootOperationType={queryRootType}
-        getScrollElement={() => containerRef.current}
-      />
-    );
+    toRender = <RootOperationDetails rootOperationType={queryRootType} />;
   }
 
   if (activePrimaryPane === 'Mutation' && mutationRootType) {
-    toRender = (
-      <RootOperationDetails
-        rootOperationType={mutationRootType}
-        getScrollElement={() => containerRef.current}
-      />
-    );
+    toRender = <RootOperationDetails rootOperationType={mutationRootType} />;
   }
 
   if (activePrimaryPane === 'Subscription' && subscriptionRootType) {
-    toRender = (
-      <RootOperationDetails
-        rootOperationType={subscriptionRootType}
-        getScrollElement={() => containerRef.current}
-      />
-    );
+    toRender = <RootOperationDetails rootOperationType={subscriptionRootType} />;
   }
 
   if (activePrimaryPane === 'Directives') {

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -12,7 +12,6 @@ import { Markdown } from '../markdown';
 import { secondaryPaneClass, secondaryPaneListClasses } from './secondary-pane.css';
 import { notificationClass } from '../../shared.styles.css';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Icon } from '../../../components';
 import fuzzysort from 'fuzzysort';
 
 const List = ({
@@ -26,7 +25,7 @@ const List = ({
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue] = useState('');
 
   const listSearchable = useMemo(() => {
     return list.map((item) => ({

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -68,7 +68,7 @@ const List = ({
           gap: 24,
         }}
       >
-        <div className={secondaryPaneListClasses.searchContainer}>
+        {/* <div className={secondaryPaneListClasses.searchContainer}>
           <div className={secondaryPaneListClasses.searchInputWrapper}>
             <Icon name="MagnifingGlass" size="small" />
             <input
@@ -80,7 +80,7 @@ const List = ({
               className={secondaryPaneListClasses.searchInput}
             />
           </div>
-        </div>
+        </div> */}
         {listSearchable.length === 0 && (
           <p className={notificationClass}>{`This schema does not contain ${name}`}</p>
         )}

--- a/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/secondary-pane/secondary-pane.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import { useRef, type ReactElement } from 'react';
 import type { GraphQLDirective, GraphQLNamedType, GraphQLObjectType } from 'graphql';
 
 import { useSchemaDocumentationStore } from '../../store';
@@ -11,38 +11,85 @@ import { Markdown } from '../markdown';
 
 import { secondaryPaneClass } from './secondary-pane.css';
 import { notificationClass } from '../../shared.styles.css';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 const List = ({
   list,
   name,
   showDescription = true,
+  getScrollElement,
 }: {
   list: GraphQLNamedType[] | readonly GraphQLDirective[];
   name: string;
   showDescription?: boolean;
+  getScrollElement: () => HTMLElement | null;
 }) => {
+  const count = list.length;
+  const virtualizer = useVirtualizer({
+    count,
+    getScrollElement: getScrollElement ?? (() => null),
+    estimateSize: () => 22,
+    enabled: !!getScrollElement,
+    scrollMargin: 48, // This is to account for the space taken by the field label at the beginning
+  });
+
+  const items = virtualizer.getVirtualItems();
+
+  if (count === 0)
+    return (
+      <Section lead={name}>
+        <p className={notificationClass}>{`This schema does not contain ${name}`}</p>
+      </Section>
+    );
+
   return (
     <Section lead={name}>
-      {list.length > 0 ? (
-        list.map((x: GraphQLNamedType | GraphQLDirective) => (
-          <SummaryType
-            key={x.name}
-            resetTertiaryPaneOnClick={true}
-            showDescription={showDescription}
-            type={x}
-          />
-        ))
-      ) : (
-        <p className={notificationClass}>{`This schema does not contain ${name}`}</p>
-      )}
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${(items[0]?.start ?? 0) - virtualizer.options.scrollMargin}px)`,
+          }}
+        >
+          {items.map((virtualRow) => {
+            const x = list[virtualRow.index];
+
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+              >
+                <SummaryType
+                  key={x.name}
+                  resetTertiaryPaneOnClick={true}
+                  showDescription={showDescription}
+                  type={x}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </Section>
   );
 };
 
 const RootOperationDetails = ({
   rootOperationType,
+  getScrollElement,
 }: {
   rootOperationType: GraphQLObjectType;
+  getScrollElement: () => HTMLElement | null;
 }) => {
   const fields = rootOperationType.getFields();
 
@@ -56,6 +103,7 @@ const RootOperationDetails = ({
         fields={fields}
         parentType={rootOperationType}
         resetTertiaryPaneOnClick={true}
+        getScrollElement={getScrollElement}
       />
     </>
   );
@@ -74,55 +122,114 @@ export const SecondaryPane = ({
   subscriptionRootType: GraphQLObjectType | null;
   sortedTypes: SortedTypeMap;
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const activePrimaryPane = useSchemaDocumentationStore.use.activePrimaryPane();
   const activeTertiaryPane = useSchemaDocumentationStore.use.activeTertiaryPane();
 
   let toRender: ReactElement = <></>;
 
   if (activePrimaryPane === 'Query' && queryRootType) {
-    toRender = <RootOperationDetails rootOperationType={queryRootType} />;
+    toRender = (
+      <RootOperationDetails
+        rootOperationType={queryRootType}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Mutation' && mutationRootType) {
-    toRender = <RootOperationDetails rootOperationType={mutationRootType} />;
+    toRender = (
+      <RootOperationDetails
+        rootOperationType={mutationRootType}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Subscription' && subscriptionRootType) {
-    toRender = <RootOperationDetails rootOperationType={subscriptionRootType} />;
+    toRender = (
+      <RootOperationDetails
+        rootOperationType={subscriptionRootType}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Directives') {
-    toRender = <List list={directives} name={'Directives'} />;
+    toRender = (
+      <List
+        list={directives}
+        name={'Directives'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Enums') {
-    toRender = <List list={sortedTypes['Enums']} name={'Enums'} />;
+    toRender = (
+      <List
+        list={sortedTypes['Enums']}
+        name={'Enums'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Input Objects') {
-    toRender = <List list={sortedTypes['Input Objects']} name={'Input Objects'} />;
+    toRender = (
+      <List
+        list={sortedTypes['Input Objects']}
+        name={'Input Objects'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Objects') {
-    toRender = <List list={sortedTypes['Objects']} name={'Objects'} />;
+    toRender = (
+      <List
+        list={sortedTypes['Objects']}
+        name={'Objects'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Scalars') {
     toRender = (
-      <List list={sortedTypes['Scalars']} name={'Scalars'} showDescription={false} />
+      <List
+        list={sortedTypes['Scalars']}
+        name={'Scalars'}
+        showDescription={false}
+        getScrollElement={() => containerRef.current}
+      />
     );
   }
 
   if (activePrimaryPane === 'Unions') {
-    toRender = <List list={sortedTypes['Unions']} name={'Unions'} />;
+    toRender = (
+      <List
+        list={sortedTypes['Unions']}
+        name={'Unions'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   if (activePrimaryPane === 'Interfaces') {
-    toRender = <List list={sortedTypes['Interfaces']} name={'Interfaces'} />;
+    toRender = (
+      <List
+        list={sortedTypes['Interfaces']}
+        name={'Interfaces'}
+        getScrollElement={() => containerRef.current}
+      />
+    );
   }
 
   return (
     <div
+      ref={containerRef}
       className={secondaryPaneClass({
         activeTertiaryPane: activeTertiaryPane !== null,
       })}

--- a/packages/react/src/schema-documentation/components/section/index.tsx
+++ b/packages/react/src/schema-documentation/components/section/index.tsx
@@ -90,11 +90,13 @@ export const SectionFields = ({
   fields,
   parentType,
   resetTertiaryPaneOnClick,
+  hideSearch,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fields: GraphQLFieldMap<any, any>;
   parentType?: GraphQLObjectType;
   resetTertiaryPaneOnClick: boolean;
+  hideSearch?: boolean;
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -133,19 +135,21 @@ export const SectionFields = ({
           gap: 24,
         }}
       >
-        <div className={sectionFieldsClasses.searchContainer}>
-          <div className={sectionFieldsClasses.searchInputWrapper}>
-            <Icon name="MagnifingGlass" size="small" />
-            <input
-              type="text"
-              name="search"
-              placeholder="Search"
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
-              className={sectionFieldsClasses.searchInput}
-            />
+        {!hideSearch && (
+          <div className={sectionFieldsClasses.searchContainer}>
+            <div className={sectionFieldsClasses.searchInputWrapper}>
+              <Icon name="MagnifingGlass" size="small" />
+              <input
+                type="text"
+                name="search"
+                placeholder="Search"
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                className={sectionFieldsClasses.searchInput}
+              />
+            </div>
           </div>
-        </div>
+        )}
         <div ref={parentRef} className={sectionFieldsClasses.fieldsListContainer}>
           <div
             style={{

--- a/packages/react/src/schema-documentation/components/section/index.tsx
+++ b/packages/react/src/schema-documentation/components/section/index.tsx
@@ -19,7 +19,6 @@ import {
   sectionLeadClass,
 } from './section.css';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Icon } from '../../../components';
 import fuzzysort from 'fuzzysort';
 
 export const Section = ({
@@ -91,7 +90,6 @@ export const SectionFields = ({
   fields,
   parentType,
   resetTertiaryPaneOnClick,
-  hideSearch,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fields: GraphQLFieldMap<any, any>;
@@ -101,7 +99,7 @@ export const SectionFields = ({
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue] = useState('');
 
   const allFields = useMemo(() => {
     return Object.keys(fields ?? {})

--- a/packages/react/src/schema-documentation/components/section/index.tsx
+++ b/packages/react/src/schema-documentation/components/section/index.tsx
@@ -149,7 +149,7 @@ export const SectionFields = ({
           gap: 24,
         }}
       >
-        {!hideSearch && (
+        {/* {!hideSearch && (
           <div className={sectionFieldsClasses.searchContainer}>
             <div className={sectionFieldsClasses.searchInputWrapper}>
               <Icon name="MagnifingGlass" size="small" />
@@ -163,7 +163,7 @@ export const SectionFields = ({
               />
             </div>
           </div>
-        )}
+        )} */}
         <div ref={parentRef} className={sectionFieldsClasses.fieldsListContainer}>
           <div
             style={{

--- a/packages/react/src/schema-documentation/components/section/section.css.ts
+++ b/packages/react/src/schema-documentation/components/section/section.css.ts
@@ -44,7 +44,7 @@ export const sectionFieldsClasses = {
     display: 'flex',
     gap: contract.space[8],
     alignItems: 'center',
-    borderBottom: `1px solid ${contract.color.neutral[9]}`,
+    borderBottom: `1px solid transparent`,
 
     selectors: {
       '&:focus-within': {

--- a/packages/react/src/schema-documentation/components/section/section.css.ts
+++ b/packages/react/src/schema-documentation/components/section/section.css.ts
@@ -1,10 +1,16 @@
-import { contract, style } from '@pathfinder-ide/style';
+import { contract, shared, style } from '@pathfinder-ide/style';
 
 export const sectionClass = style({
   display: 'flex',
   flexDirection: 'column',
   marginBottom: 24,
   color: contract.color.neutral[12],
+
+  selectors: {
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  },
 });
 
 export const sectionLeadClass = style({
@@ -21,3 +27,45 @@ export const enumValueClass = style({
   color: contract.color.green[10],
   marginBottom: 8,
 });
+
+export const sectionFieldsClasses = {
+  container: style({
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+
+  searchContainer: style({}),
+
+  searchInputWrapper: style({
+    paddingBlock: contract.space[4],
+    color: contract.color.neutral[11],
+    fontSize: 14,
+    display: 'flex',
+    gap: contract.space[8],
+    alignItems: 'center',
+    borderBottom: `1px solid ${contract.color.neutral[9]}`,
+
+    selectors: {
+      '&:focus-within': {
+        borderBottomColor: contract.color.neutral[12],
+        color: contract.color.neutral[12],
+      },
+    },
+  }),
+
+  searchInput: style({
+    background: 'transparent',
+    width: '100%',
+    outline: 'none',
+  }),
+
+  fieldsListContainer: style([
+    shared.scrollbars,
+    {
+      flex: 1,
+      overflowY: 'auto',
+      contain: 'strict',
+    },
+  ]),
+};

--- a/packages/react/src/schema-documentation/components/summary/summary.css.ts
+++ b/packages/react/src/schema-documentation/components/summary/summary.css.ts
@@ -4,6 +4,12 @@ export const summaryFieldClass = style({
   borderLeft: `1px solid ${contract.color.neutral[4]}`,
   margin: '12px 0',
   paddingLeft: 8,
+
+  selectors: {
+    '&:first-child': {
+      marginTop: 0,
+    },
+  },
 });
 
 export const summaryTypeClass = style({

--- a/packages/react/src/schema-documentation/components/summary/summary.css.ts
+++ b/packages/react/src/schema-documentation/components/summary/summary.css.ts
@@ -16,5 +16,4 @@ export const summaryTypeClass = style({
   display: 'flex',
   flexDirection: 'column',
   borderLeft: contract.color.neutral[6],
-  margin: '8px 0',
 });

--- a/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, useRef } from 'react';
 
 import {
   isDirective,
@@ -44,6 +44,8 @@ export const TertiaryPane = ({
   pane: TertiaryPaneType;
   fieldSlotComponent?: ReactNode;
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const activeTertiaryPane = useSchemaDocumentationStore.use.activeTertiaryPane();
   const tertiaryPaneStack = useSchemaDocumentationStore.use.tertiaryPaneStack();
   const { clearTertiaryPaneStack, navigateTertiaryPaneStack } =
@@ -76,7 +78,7 @@ export const TertiaryPane = ({
     }
     if (isObjectType(pane)) {
       leadType = 'Object';
-      toRender = <LeafObject type={pane} />;
+      toRender = <LeafObject type={pane} getScrollElement={() => containerRef.current} />;
     }
     if (isUnionType(pane)) {
       leadType = 'Union';
@@ -86,7 +88,7 @@ export const TertiaryPane = ({
 
   if (activeTertiaryPane && isInterfaceType(pane)) {
     leadType = 'Interface';
-    toRender = <LeafInterface int={pane} />;
+    toRender = <LeafInterface int={pane} getScrollElement={() => containerRef.current} />;
   }
 
   if (activeTertiaryPane && isDirective(pane)) {
@@ -105,7 +107,7 @@ export const TertiaryPane = ({
   }
 
   return (
-    <div className={tertiaryPaneClass}>
+    <div className={tertiaryPaneClass} ref={containerRef}>
       <div className={tertiaryPaneLeadClass}>
         <div className={tertiaryPaneLeadInfoClass}>
           <span className={tertiaryPaneLeadInfoSpanClass}>{leadType}</span>

--- a/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
+++ b/packages/react/src/schema-documentation/components/tertiary-pane/tertiary-pane.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useRef } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 import {
   isDirective,
@@ -44,8 +44,6 @@ export const TertiaryPane = ({
   pane: TertiaryPaneType;
   fieldSlotComponent?: ReactNode;
 }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const activeTertiaryPane = useSchemaDocumentationStore.use.activeTertiaryPane();
   const tertiaryPaneStack = useSchemaDocumentationStore.use.tertiaryPaneStack();
   const { clearTertiaryPaneStack, navigateTertiaryPaneStack } =
@@ -78,7 +76,7 @@ export const TertiaryPane = ({
     }
     if (isObjectType(pane)) {
       leadType = 'Object';
-      toRender = <LeafObject type={pane} getScrollElement={() => containerRef.current} />;
+      toRender = <LeafObject type={pane} />;
     }
     if (isUnionType(pane)) {
       leadType = 'Union';
@@ -88,7 +86,7 @@ export const TertiaryPane = ({
 
   if (activeTertiaryPane && isInterfaceType(pane)) {
     leadType = 'Interface';
-    toRender = <LeafInterface int={pane} getScrollElement={() => containerRef.current} />;
+    toRender = <LeafInterface int={pane} />;
   }
 
   if (activeTertiaryPane && isDirective(pane)) {
@@ -107,7 +105,7 @@ export const TertiaryPane = ({
   }
 
   return (
-    <div className={tertiaryPaneClass} ref={containerRef}>
+    <div className={tertiaryPaneClass}>
       <div className={tertiaryPaneLeadClass}>
         <div className={tertiaryPaneLeadInfoClass}>
           <span className={tertiaryPaneLeadInfoSpanClass}>{leadType}</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.10.8
         version: 3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      fuzzysort:
+        specifier: ^3.0.2
+        version: 3.0.2
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -3649,6 +3652,9 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuzzysort@3.0.2:
+    resolution: {integrity: sha512-ZyahVgxvckB1Qosn7YGWLDJJp2XlyaQ2WmZeI+d0AzW0AMqVYnz5N89G6KAKa6m/LOtv+kzJn4lhDF/yVg11Cg==}
 
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
@@ -10359,6 +10365,8 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
+
+  fuzzysort@3.0.2: {}
 
   gauge@3.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 1.14.2
       '@vanilla-extract/vite-plugin':
         specifier: 3.9.5
-        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
+        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
       '@vitejs/plugin-react':
         specifier: 4.3.1
         version: 4.3.1(vite@5.4.3(@types/node@22.7.4))
@@ -97,7 +97,7 @@ importers:
         version: 5.7.0(graphql@16.9.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)
 
   apps/ladle:
     dependencies:
@@ -137,7 +137,7 @@ importers:
         version: 18.3.0
       '@vanilla-extract/vite-plugin':
         specifier: 3.9.5
-        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
+        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
       '@vitejs/plugin-react':
         specifier: 4.3.1
         version: 4.3.1(vite@5.4.3(@types/node@22.7.4))
@@ -155,7 +155,7 @@ importers:
         version: 3.6.2(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@4.5.3(@types/node@22.7.4))
       '@astrojs/tailwind':
         specifier: 5.1.0
-        version: 5.1.0(astro@3.6.5(@types/node@22.7.4)(typescript@5.5.4))(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)))(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
+        version: 5.1.0(astro@3.6.5(@types/node@22.7.4)(typescript@5.5.4))(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
       '@astrojs/vercel':
         specifier: 7.8.1
         version: 7.8.1(astro@3.6.5(@types/node@22.7.4)(typescript@5.5.4))(next@13.5.3(@babel/core@7.24.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -176,7 +176,7 @@ importers:
         version: 0.33.4
       tailwindcss:
         specifier: 3.4.4
-        version: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
+        version: 3.4.4(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
 
   examples/nextjs-example:
     dependencies:
@@ -201,6 +201,9 @@ importers:
       eslint-config-next:
         specifier: 13.4.12
         version: 13.4.12(eslint@8.56.0)(typescript@5.1.6)
+      graphql:
+        specifier: ^16.9.0
+        version: 16.9.0
       next:
         specifier: 13.5.3
         version: 13.5.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -218,7 +221,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tailwindcss:
         specifier: 3.4.1
-        version: 3.4.1(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6))
+        version: 3.4.1(ts-node@10.9.2(@types/node@20.4.5)(typescript@5.1.6))
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -292,6 +295,9 @@ importers:
       '@headlessui/react':
         specifier: 1.7.19
         version: 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.10.8
+        version: 3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -364,7 +370,7 @@ importers:
         version: 0.5.5(@vanilla-extract/css@1.14.2)
       '@vanilla-extract/vite-plugin':
         specifier: 3.9.5
-        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
+        version: 3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))
       '@vitejs/plugin-react':
         specifier: 4.3.1
         version: 4.3.1(vite@5.4.3(@types/node@22.7.4))
@@ -379,7 +385,7 @@ importers:
         version: 22.1.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)
       vite:
         specifier: 5.4.3
         version: 5.4.3(@types/node@22.7.4)
@@ -1930,14 +1936,14 @@ packages:
   '@swc/types@0.1.9':
     resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
 
-  '@tanstack/react-virtual@3.8.3':
-    resolution: {integrity: sha512-9ICwbDUUzN99CJIGc373i8NLoj6zFTKI2Hlcmo0+lCSAhPQ5mxq4dGOMKmLYoEFyHcGQ64Bd6ZVbnPpM6lNK5w==}
+  '@tanstack/react-virtual@3.10.8':
+    resolution: {integrity: sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@tanstack/virtual-core@3.8.3':
-    resolution: {integrity: sha512-vd2A2TnM5lbnWZnHi9B+L2gPtkSeOtJOAw358JqokIH1+v2J7vUAzFVPwB/wrye12RFOurffXu33plm4uQ+JBQ==}
+  '@tanstack/virtual-core@3.10.8':
+    resolution: {integrity: sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==}
 
   '@tauri-apps/api@1.6.0':
     resolution: {integrity: sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==}
@@ -6693,13 +6699,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@astrojs/tailwind@5.1.0(astro@3.6.5(@types/node@22.7.4)(typescript@5.5.4))(tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)))(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))':
+  '@astrojs/tailwind@5.1.0(astro@3.6.5(@types/node@22.7.4)(typescript@5.5.4))(tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4)))(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))':
     dependencies:
       astro: 3.6.5(@types/node@22.7.4)(typescript@5.5.4)
       autoprefixer: 10.4.19(postcss@8.4.39)
       postcss: 8.4.39
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
-      tailwindcss: 3.4.4(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
+      tailwindcss: 3.4.4(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
     transitivePeerDependencies:
       - ts-node
 
@@ -7454,7 +7460,7 @@ snapshots:
 
   '@headlessui/react@1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tanstack/react-virtual': 3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual': 3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       client-only: 0.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8021,13 +8027,13 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tanstack/react-virtual@3.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/react-virtual@3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tanstack/virtual-core': 3.8.3
+      '@tanstack/virtual-core': 3.10.8
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@tanstack/virtual-core@3.8.3': {}
+  '@tanstack/virtual-core@3.10.8': {}
 
   '@tauri-apps/api@1.6.0': {}
 
@@ -8570,12 +8576,31 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.14.2
 
-  '@vanilla-extract/vite-plugin@3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))':
+  '@vanilla-extract/vite-plugin@3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))':
     dependencies:
       '@vanilla-extract/integration': 6.5.0(@types/node@22.7.4)
       outdent: 0.8.0
       postcss: 8.4.27
-      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4))
+      vite: 5.4.3(@types/node@22.7.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
+
+  '@vanilla-extract/vite-plugin@3.9.5(@types/node@22.7.4)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))(vite@5.4.3(@types/node@22.7.4))':
+    dependencies:
+      '@vanilla-extract/integration': 6.5.0(@types/node@22.7.4)
+      outdent: 0.8.0
+      postcss: 8.4.27
+      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
       vite: 5.4.3(@types/node@22.7.4)
     transitivePeerDependencies:
       - '@types/node'
@@ -12539,29 +12564,37 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.27
 
-  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6)):
+  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.27
-      ts-node: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6)
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.2(@types/node@20.4.5)(typescript@5.1.6)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.27
-      ts-node: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.4.5)(typescript@5.1.6)
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.4.27)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.4.5
+    optionalDependencies:
+      postcss: 8.4.27
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)
+
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4)
 
   postcss-nested@6.0.1(postcss@8.4.27):
     dependencies:
@@ -13392,7 +13425,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6)):
+  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.4.5)(typescript@5.1.6)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -13411,7 +13444,7 @@ snapshots:
       postcss: 8.4.27
       postcss-import: 15.1.0(postcss@8.4.27)
       postcss-js: 4.0.1(postcss@8.4.27)
-      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6))
+      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@types/node@20.4.5)(typescript@5.1.6))
       postcss-nested: 6.0.1(postcss@8.4.27)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -13419,7 +13452,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.4(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4)):
+  tailwindcss@3.4.4(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -13438,7 +13471,7 @@ snapshots:
       postcss: 8.4.27
       postcss-import: 15.1.0(postcss@8.4.27)
       postcss-js: 4.0.1(postcss@8.4.27)
-      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.27)(ts-node@10.9.2(@types/node@22.7.4)(typescript@5.5.4))
       postcss-nested: 6.0.1(postcss@8.4.27)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -13558,28 +13591,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@20.4.5)(typescript@5.1.6):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.5
-      acorn: 8.12.1
-      acorn-walk: 8.3.3
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.1.6
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.6.13(@swc/helpers@0.5.2)
-    optional: true
-
-  ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.2))(@types/node@22.7.4)(typescript@5.5.4):
+  ts-node@10.9.2(@swc/core@1.6.13)(@types/node@22.7.4)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13598,6 +13610,25 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.6.13(@swc/helpers@0.5.2)
+
+  ts-node@10.9.2(@types/node@20.4.5)(typescript@5.1.6):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.4.5
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tsconfck@3.1.1(typescript@5.5.4):
     optionalDependencies:
@@ -13898,9 +13929,9 @@ snapshots:
   vite-node@1.6.0(@types/node@22.7.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.5
+      debug: 4.3.6
       pathe: 1.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.0
       vite: 5.4.3(@types/node@22.7.4)
     transitivePeerDependencies:
       - '@types/node'


### PR DESCRIPTION
# Description

This PR contains updates to several components to make them better able to handle large schemas.

# The changes include:
- Use virtualization for operations builder tab.
- Lazy render some components only when viewed.
- Change the way some components are passed & used so that they are not un-mounted & re-mounted again on re-renders
- Memoize some of the heavier calculations 
- Add virtualization to schema documentation's tab sections lists.



# The schema I used
I have generated a schema that is relatively big & used it while testing.
The schema consists of 400 root queries, each query contains 3 fields & goes 5 levels deep.
So it contains a total of around 150_000 types.

Here's the schema if you want to test with it:
[schema.txt](https://github.com/user-attachments/files/17189591/schema.txt)

& Here's the script I used to generate the schema if you would like to try generating bigger schemas or adding different fields.
[generate-large-schema-script.zip](https://github.com/user-attachments/files/17189772/generate-large-schema-script.zip)

Note that the time complexity of the script above is `O( numberOfTypes * numberOfFields ^ maxDepth )`
So `maxDepth` value can't be more than 6-8 without reaching `O(10^6)` complexity.

And if you have other large schemas that you could test this PR with, it'd be great.



# Some benchmarks
Testing with the schema above on my machine (a relatively powerful one), here are some before/after benchmarks for the time it takes between an interaction & the next paint:

|                                                                 | Before                      | After |
|-----------------------------------------------------------------|-----------------------------|-------|
| Clicking on a field in operations builder                       | Minimum of 344ms | 48ms  |
| Switching between tabs                                          | Minimum of 700ms                | 40ms  |
| Opening a section with +100k fields in schema documentation tab | A few seconds               | 48ms  |

(And during development, the above values could be doubled due to double rendering in React)

Of course these values could change quite a bit across different devices & browsers. 

# Notes
- If I missed some section/component that is still affected by large schemas, let me know.
- If there are further/better optimizations to some parts, let me know.
- It should be mentioned that one of the drawbacks of virtualization is that CMD-F (or the native find-on-page) won't work anymore since the items are not even rendered, so we will likely need to introduce a custom search input in all the sections that got virtualized to keep a good user experience. Though I think we should do that in a separate PR.


# Type of change

- [ ] 💔 Breaking
- [ ] 🚀 Feature
- [ ] 🐛 Fix
- [ ] 🛠️ Tooling
- [X] 🔨 Refactoring
- [ ] 🧪 Test
- [ ] 📦 Dependency
- [ ] 📖 Requires documentation update
