### PR TITLE
Fix compatibility with graphql sse

### DIFF
--- a/.changeset/long-cobras-peel.md
+++ b/.changeset/long-cobras-peel.md
@@ -1,0 +1,5 @@
+---
+'@pathfinder-ide/react': patch
+---
+
+Fix compatibility issue with `graphql-sse`

--- a/packages/stores/src/schema-store/actions/http-fetcher.ts
+++ b/packages/stores/src/schema-store/actions/http-fetcher.ts
@@ -1,4 +1,4 @@
-import { getEnabledTTPHeaderValues } from '../../session-store';
+import { getEnabledHTTPHeaderValues } from '../../session-store';
 import type { SchemaStoreActions } from '../schema-store.types';
 import { useSchemaStore } from '../use-schema-store';
 
@@ -11,7 +11,7 @@ export const httpFetcher: SchemaStoreActions['httpFetcher'] = async ({
   const fetchResponse = await fetch(fetchOptions.endpoint, {
     method: 'POST',
     headers: fetchOptions.headers
-      ? getEnabledTTPHeaderValues({ headers: fetchOptions.headers })
+      ? getEnabledHTTPHeaderValues({ headers: fetchOptions.headers })
       : undefined,
     credentials: 'same-origin',
     body,

--- a/packages/stores/src/session-store/index.ts
+++ b/packages/stores/src/session-store/index.ts
@@ -11,7 +11,7 @@ export { clearHistory, deleteFromHistory } from './slices/history/actions';
 
 export {
   addEmptyHeader,
-  getEnabledTTPHeaderValues,
+  getEnabledHTTPHeaderValues,
   getEnabledHTTPHeaderValueRecord,
   removeHeader,
   updateHeader,

--- a/packages/stores/src/session-store/slices/http-headers/actions/get-enabled-http-header-values.ts
+++ b/packages/stores/src/session-store/slices/http-headers/actions/get-enabled-http-header-values.ts
@@ -1,6 +1,6 @@
 import { HTTPHeadersActions } from '../http-headers.types';
 
-export const getEnabledTTPHeaderValues: HTTPHeadersActions['getEnabledTTPHeaderValues'] =
+export const getEnabledHTTPHeaderValues: HTTPHeadersActions['getEnabledHTTPHeaderValues'] =
   ({ headers }) => {
     return headers
       .filter((header) => header.enabled)

--- a/packages/stores/src/session-store/slices/http-headers/actions/get-enabled-http-header-values.ts
+++ b/packages/stores/src/session-store/slices/http-headers/actions/get-enabled-http-header-values.ts
@@ -9,12 +9,14 @@ export const getEnabledHTTPHeaderValues: HTTPHeadersActions['getEnabledHTTPHeade
 
 export const getEnabledHTTPHeaderValueRecord: HTTPHeadersActions['getEnabledHTTPHeaderValueRecord'] =
   ({ headers }) => {
+    // we use this function to prepare headers for the graphql-sse client
+    // we're calling lowercase here to ensure that graphql-sse correctly merges headers ("Content-Type"): https://github.com/enisdenjo/graphql-sse/commit/0084de7c7f55c77c9b9156b98c264b90f49bf2b2
     return headers
       .filter((header) => header.enabled)
       .reduce(
         (accumulator, currentValue) => ({
           ...accumulator,
-          [currentValue.key]: currentValue.value,
+          [currentValue.key.toLowerCase()]: currentValue.value,
         }),
         {} as Record<string, string>,
       );

--- a/packages/stores/src/session-store/slices/http-headers/actions/index.ts
+++ b/packages/stores/src/session-store/slices/http-headers/actions/index.ts
@@ -1,7 +1,7 @@
 export { addEmptyHeader } from './add-empty-header';
 
 export {
-  getEnabledTTPHeaderValues,
+  getEnabledHTTPHeaderValues,
   getEnabledHTTPHeaderValueRecord,
 } from './get-enabled-http-header-values';
 

--- a/packages/stores/src/session-store/slices/http-headers/http-headers.types.ts
+++ b/packages/stores/src/session-store/slices/http-headers/http-headers.types.ts
@@ -16,7 +16,11 @@ export type UpdateHeaderStatus = {
 
 export type HTTPHeadersActions = {
   addEmptyHeader: ({ enabled }: { enabled?: boolean }) => void;
-  getEnabledTTPHeaderValues: ({ headers }: { headers: HTTPHeaderValue[] }) => HeadersInit;
+  getEnabledHTTPHeaderValues: ({
+    headers,
+  }: {
+    headers: HTTPHeaderValue[];
+  }) => HeadersInit;
   getEnabledHTTPHeaderValueRecord: ({
     headers,
   }: {


### PR DESCRIPTION
This PR fixes a bug with our usage of the `graphql-sse` package, where passed-in headers are manually merged [here](https://github.com/enisdenjo/graphql-sse/commit/0084de7c7f55c77c9b9156b98c264b90f49bf2b2). Lowercasing our keys before we create our client ensures a clean merge.
